### PR TITLE
Try fixing CI for ktor inngest-test-server with Java 17

### DIFF
--- a/inngest-test-server/build.gradle.kts
+++ b/inngest-test-server/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
-java { toolchain { languageVersion.set(JavaLanguageVersion.of(20)) } }
+java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
 application {
     // Define the main class for the application.


### PR DESCRIPTION
We are seeing this error, so picking Java 17 for now since it's one of the supported  LTS versions

https://github.com/inngest/inngest-kt/actions/runs/8028420744/job/21933603294

> Cannot find a Java installation on your machine matching this tasks requirements: {languageVersion=20, vendor=any, implementation=vendor-specific} for LINUX on x86_64.