### PR TITLE
Fixes NoClassDefFoundError crash when calling function from Java

### DIFF
--- a/inngest-spring-boot-demo/build.gradle.kts
+++ b/inngest-spring-boot-demo/build.gradle.kts
@@ -22,6 +22,14 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.boot:spring-boot-dependencies:2.7.18") {
+            bomProperty("kotlin.version", "1.9.10")
+        }
+    }
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
 }


### PR DESCRIPTION
Spring boot's dependency management plugin is forcing Kotlin 1.6.21 into the classpath because springframework 2.7.18 depends on it: https://docs.spring.io/spring-boot/docs/2.7.18/reference/html/dependency-versions.html#appendix.dependency-versions.coordinates

So this overrides the Kotlin version to 1.9.10, which is the same as `inngest-core`'s Kotlin version.

Solution found in: https://youtrack.jetbrains.com/issue/KT-58021/NoClassDefFoundError-kotlin-enums-EnumEntries-with-language-version-1.9-or-2.0#focus=Comments-27-7955046.0-0

Stack trace:
```kotlin
  Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Handler dispatch failed; nested exception is java.lang.NoClassDefFoundError: kotlin/enums/EnumEntriesKt] with root cause

java.lang.ClassNotFoundException: kotlin.enums.EnumEntriesKt
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641) ~[na:na]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188) ~[na:na]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521) ~[na:na]
	at com.inngest.OpCode.<clinit>(Function.kt:26) ~[main/:na]
	at com.inngest.InngestFunction.call(Function.kt:124) ~[main/:na]
	at com.inngest.CommHandler.callFunction(Comm.kt:85) ~[main/:na]
	at com.inngest.springbootdemo.InngestController.handleRequest(InngestController.java:40) ~[main/:na]
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104) ~[na:na]
	at java.base/java.lang.reflect.Method.invoke(Method.java:578) ~[na:na]
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
```