### PR TITLE
Fix Java interop serialization issues 

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/State.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/State.kt
@@ -16,15 +16,18 @@ class State(val payloadJson: String) {
             sb.append(String.format("%02x", byte))
         }
         return sb.toString()
+
     }
 
-    inline fun <reified T> getState(hashedId: String): T? {
+    inline fun <reified T> getState(hashedId: String): T? = getState(hashedId, T::class.java)
+
+    fun <T> getState(hashedId: String, type: Class<T>): T? {
         val mapper = ObjectMapper()
         val node: JsonNode = mapper.readTree(payloadJson)
         val stepResult = node.path("steps").get(hashedId) ?: throw StateNotFound()
         if (stepResult.has("data")) {
             val dataNode = stepResult.get("data")
-            return mapper.treeToValue(dataNode, T::class.java)
+            return mapper.treeToValue(dataNode, type)
         } else if (stepResult.has("error")) {
             // TODO - Parse the error and throw it
             return null

--- a/inngest-core/src/main/kotlin/com/inngest/State.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/State.kt
@@ -16,12 +16,14 @@ class State(val payloadJson: String) {
             sb.append(String.format("%02x", byte))
         }
         return sb.toString()
-
     }
 
     inline fun <reified T> getState(hashedId: String): T? = getState(hashedId, T::class.java)
 
-    fun <T> getState(hashedId: String, type: Class<T>): T? {
+    fun <T> getState(
+        hashedId: String,
+        type: Class<T>,
+    ): T? {
         val mapper = ObjectMapper()
         val node: JsonNode = mapper.readTree(payloadJson)
         val stepResult = node.path("steps").get(hashedId) ?: throw StateNotFound()

--- a/inngest-core/src/main/kotlin/com/inngest/Step.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Step.kt
@@ -25,15 +25,14 @@ class Step(val state: State) {
      * @param id unique step id for memoization
      * @param fn the function to run
      */
-    inline fun <reified T> run(
-        id: String,
-        fn: () -> T,
-    ): T {
+    inline fun <reified T> run(id: String, noinline fn: () -> T): T = run(id, fn, T::class.java)
+
+    fun <T> run(id: String, fn: () -> T, type: Class<T>): T {
         val hashedId = state.getHashFromId(id)
 
         try {
-            val stepResult = state.getState<T>(hashedId)
-            if (stepResult is T) {
+            val stepResult = state.getState(hashedId, type)
+            if (stepResult != null) {
                 return stepResult
             }
         } catch (e: StateNotFound) {

--- a/inngest-core/src/main/kotlin/com/inngest/Step.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Step.kt
@@ -25,9 +25,16 @@ class Step(val state: State) {
      * @param id unique step id for memoization
      * @param fn the function to run
      */
-    inline fun <reified T> run(id: String, noinline fn: () -> T): T = run(id, fn, T::class.java)
+    inline fun <reified T> run(
+        id: String,
+        noinline fn: () -> T,
+    ): T = run(id, fn, T::class.java)
 
-    fun <T> run(id: String, fn: () -> T, type: Class<T>): T {
+    fun <T> run(
+        id: String,
+        fn: () -> T,
+        type: Class<T>,
+    ): T {
         val hashedId = state.getHashFromId(id)
 
         try {

--- a/inngest-core/src/test/kotlin/com/inngest/StateTest.kt
+++ b/inngest-core/src/test/kotlin/com/inngest/StateTest.kt
@@ -34,7 +34,7 @@ internal class StateTest {
         val state = State(json)
         val hashedId = state.getHashFromId("something-not-in-state")
         assertFailsWith<StateNotFound> {
-            state.getState<DummyClass>(hashedId)
+            state.getState<Int>(hashedId)
         }
     }
 

--- a/inngest-spring-boot-demo/build.gradle.kts
+++ b/inngest-spring-boot-demo/build.gradle.kts
@@ -33,4 +33,3 @@ dependencyManagement {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
-

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/InngestSingleton.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/InngestSingleton.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-
+// TODO: Fix the serialization yielding an empty object in `Klaxon().toJsonString(body)`
 class Result {
     @JsonProperty("sum")
     private final int sum;
@@ -38,26 +38,22 @@ public class InngestSingleton {
 
                 System.out.println("-> handler called " + ctx.getEvent().getName());
 
-                // Steps types are problematic for now as it's not possible to called
-                // reified types from Java.
+                int y = step.run("add-ten", () -> x + 10, Integer.class);
 
-//                int y = step.run("add-ten", () -> x + 10);
+                Result res = step.run("cast-to-type-add-ten", () -> {
+                    System.out.println("-> running step 1!! " + x);
+                    return new Result(y + 10);
+                }, Result.class);
 
-//                Result res = step.run("cast-to-type-add-ten", () -> {
-//                    System.out.println("-> running step 1!! " + x);
-//                    // throw new Exception("An error!");
-//                    return new Result(y + 10);
-//                });
-
-//                System.out.println("res" + res);
-//                int add = step.run("add-one-hundred", () -> {
-//                    System.out.println("-> running step 2 :) " + (res != null ? res.getSum() : ""));
-//                    return (res != null ? res.getSum() : 0) + 100;
-//                });
+                System.out.println("res" + res);
+                int add = step.run("add-one-hundred", () -> {
+                    System.out.println("-> running step 2 :) " + (res != null ? res.getSum() : ""));
+                    return (res != null ? res.getSum() : 0) + 100;
+                }, Integer.class);
 
                 step.sleep("wait-one-sec", Duration.ofSeconds(2));
 
-//                step.run("last-step", () -> (res != null ? res.getSum() : 0) * add);
+                step.run("last-step", () -> (res != null ? res.getSum() : 0) * add, Integer.class);
 
                 return null;
             };

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/InngestSingleton.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/InngestSingleton.java
@@ -6,22 +6,6 @@ import kotlin.jvm.functions.Function2;
 import java.time.Duration;
 import java.util.HashMap;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-// TODO: Fix the serialization yielding an empty object in `Klaxon().toJsonString(body)`
-class Result {
-    @JsonProperty("sum")
-    private final int sum;
-
-    public Result(@JsonProperty("sum") int sum) {
-        this.sum = sum;
-    }
-
-    public int getSum() {
-        return sum;
-    }
-}
-
 // NOTE: We probably don't need this singleton anymore
 // when revisiting the SDK's interface.
 public class InngestSingleton {
@@ -33,7 +17,7 @@ public class InngestSingleton {
             FunctionTrigger[] triggers = {fnTrigger};
             FunctionOptions fnConfig = new FunctionOptions("fn-id-slug", "My function!", triggers);
 
-            Function2<FunctionContext, Step, Void> handler = (ctx, step) -> {
+            Function2<FunctionContext, Step, HashMap<String, String>> handler = (ctx, step) -> {
                 int x = 10;
 
                 System.out.println("-> handler called " + ctx.getEvent().getName());
@@ -47,15 +31,17 @@ public class InngestSingleton {
 
                 System.out.println("res" + res);
                 int add = step.run("add-one-hundred", () -> {
-                    System.out.println("-> running step 2 :) " + (res != null ? res.getSum() : ""));
-                    return (res != null ? res.getSum() : 0) + 100;
+                    System.out.println("-> running step 2 :) " + (res != null ? res.sum : ""));
+                    return (res != null ? res.sum : 0) + 100;
                 }, Integer.class);
 
                 step.sleep("wait-one-sec", Duration.ofSeconds(2));
 
-                step.run("last-step", () -> (res != null ? res.getSum() : 0) * add, Integer.class);
+                step.run("last-step", () -> (res != null ? res.sum : 0) * add, Integer.class);
 
-                return null;
+                return new HashMap<String, String>() {{
+                    put("message", "cool - this finished running");
+                }};
             };
             InngestFunction function = new InngestFunction(fnConfig, handler);
 

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/Result.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/Result.java
@@ -1,0 +1,12 @@
+package com.inngest.springbootdemo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Result {
+    @JsonProperty("sum")
+    public final int sum;
+
+    public Result(@JsonProperty("sum") int sum) {
+        this.sum = sum;
+    }
+}


### PR DESCRIPTION
Introduces two serialization fixes for the Java steps calls:
- Creating new versions of reified functions that explicitly require a class type.
It's not possible to call reified inline Kotlin methods from Java
so steps return types will have to be explicitly passed.
Without `reified inline` generic types are lost by at runtime and
cannot be used anymore for deserialization purposes.
https://stackoverflow.com/questions/42741780/how-can-i-call-kotlin-methods-with-reified-generics-from-java/42742119#42742119
- For now steps return types will need to be:
    - Public classes
    - Having public `JsonProperty`s

So that Getters can be called from the `inngest-core` package.
It's quite limiting I think. Getters do not work as expected with Klaxon 
unless it's declared in Kotlin. But we'll try to improve it later on.
