### PR TITLE
INN-2310: Implement step.sendEvent

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -45,6 +45,8 @@ data class CommError(
     val __serialized: Boolean = true,
 )
 
+val jsonMediaType = "application/json".toMediaType()
+
 class CommHandler(val functions: HashMap<String, InngestFunction>) {
     private fun getHeaders(): Map<String, String> {
         return mapOf(
@@ -114,6 +116,39 @@ class CommHandler(val functions: HashMap<String, InngestFunction>) {
         return configs
     }
 
+    companion object Client {
+        inline fun <reified T> sendEvent(payload: Any): T? {
+            val eventKey = "test"
+            return send("http://localhost:8288/e/$eventKey", payload)
+        }
+
+        inline fun <reified T> send(
+            url: String,
+            payload: Any,
+        ): T? {
+            val jsonRequestBody = Klaxon().toJsonString(payload)
+            val requestBody = jsonRequestBody.toRequestBody(jsonMediaType)
+
+            val client = OkHttpClient()
+
+            // TODO - Add missing headers
+            val request =
+                Request.Builder()
+                    .url(url)
+                    .post(requestBody)
+                    .build()
+
+            client.newCall(request).execute().use { response ->
+                // TODO: Handle error case
+                if (!response.isSuccessful) throw IOException("Unexpected code $response")
+                if (Unit::class.java.isAssignableFrom(T::class.java)) {
+                    return Unit as T
+                }
+                return Klaxon().parse<T>(response.body!!.charStream())
+            }
+        }
+    }
+
     fun register(): String {
         // TODO - This should detect the dev server or use base url
         val registrationUrl = "http://localhost:8288/fn/register"
@@ -126,30 +161,8 @@ class CommHandler(val functions: HashMap<String, InngestFunction>) {
                 v = "0.0.1",
                 functions = getFunctionConfigs(),
             )
-        val jsonRequestBody = Klaxon().toJsonString(requestPayload)
 
-        val client = OkHttpClient()
-
-        val jsonMediaType = "application/json".toMediaType()
-        val requestBody = jsonRequestBody.toRequestBody(jsonMediaType)
-
-        // TODO - Add headers?
-        val request =
-            Request.Builder()
-                .url(registrationUrl).addHeader("Content-Type", "application/json")
-                .post(requestBody)
-                .build()
-
-        client.newCall(request).execute().use { response ->
-            if (!response.isSuccessful) throw IOException("Unexpected code $response")
-
-            // TODO - Decode response and relay any message
-//            for ((name, value) in response.headers) {
-//                println("$name: $value")
-//            }
-//
-//            println(response.body!!.string())
-        }
+        send<Unit>(registrationUrl, requestPayload)
 
         // TODO - Add headers to output
         val body: Map<String, Any?> = mapOf()

--- a/inngest-core/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Function.kt
@@ -19,7 +19,8 @@ data class FunctionTrigger(
 enum class OpCode {
     StepRun,
     Sleep,
-    StepStateFailed, // TODO
+    StepStateFailed,
+    Step,
 
     // FUTURE:
     WaitForEvent,
@@ -91,6 +92,9 @@ data class FunctionContext(
  * @param config The options for the function
  * @param handler The function to be called when the function is triggered
  */
+
+data class SendEventPayload(val event_ids: Array<String>)
+
 open class InngestFunction(
     val config: FunctionOptions,
     val handler: (ctx: FunctionContext, step: Step) -> kotlin.Any?,
@@ -115,6 +119,14 @@ open class InngestFunction(
                 name = "",
                 op = OpCode.StepRun,
                 statusCode = ResultStatusCode.FunctionComplete,
+            )
+        } catch (e: StepInterruptSendEventException) {
+            return StepResult(
+                id = e.hashedId,
+                name = e.id,
+                op = OpCode.Step,
+                statusCode = ResultStatusCode.StepComplete,
+                data = SendEventPayload(e.eventIds),
             )
         } catch (e: StepInterruptSleepException) {
             return StepOptions(

--- a/inngest-core/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Function.kt
@@ -19,7 +19,7 @@ data class FunctionTrigger(
 enum class OpCode {
     StepRun,
     Sleep,
-    StepStateFailed,
+    StepStateFailed, // TODO
     Step,
 
     // FUTURE:

--- a/inngest-core/src/main/kotlin/com/inngest/State.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/State.kt
@@ -35,6 +35,7 @@ class State(val payloadJson: String) {
             return null
         }
         // NOTE - Sleep steps will be stored as null
+        // TODO - Investigate if sendEvents stores null as well.
         // TODO - Check the state is actually null
         return null
     }

--- a/inngest-core/src/main/kotlin/com/inngest/Step.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Step.kt
@@ -5,6 +5,10 @@ import java.time.Duration
 typealias MemoizedRecord = HashMap<String, Any>
 typealias MemoizedState = HashMap<String, MemoizedRecord>
 
+data class InngestEvent(val name: String, val data: Any)
+
+data class SendEventsResponse(val ids: Array<String>)
+
 class StepInvalidStateTypeException(val id: String, val hashedId: String) : Throwable("Step execution interrupted")
 
 class StepStateTypeMismatchException(val id: String, val hashedId: String) : Throwable("Step execution interrupted")
@@ -14,6 +18,9 @@ open class StepInterruptException(val id: String, val hashedId: String, open val
 
 class StepInterruptSleepException(id: String, hashedId: String, override val data: String) :
     StepInterruptException(id, hashedId, data)
+
+class StepInterruptSendEventException(id: String, hashedId: String, val eventIds: Array<String>) :
+    StepInterruptException(id, hashedId, eventIds)
 
 // TODO: Add name, stack, etc. if poss
 class StepError(message: String) : Exception(message)
@@ -75,6 +82,45 @@ class Step(val state: State) {
         } catch (e: StateNotFound) {
             val durationInSeconds = duration.getSeconds()
             throw StepInterruptSleepException(id, hashedId, "${durationInSeconds}s")
+        }
+    }
+
+    /**
+     * Sends multiple event to Inngest
+     *
+     * @param id Unique step id for memoization.
+     * @param event An event payload object.
+     *
+     */
+
+    fun sendEvent(
+        id: String,
+        event: InngestEvent,
+    ) = sendEvent(id, arrayOf(event))
+
+    /**
+     * Sends a single event to Inngest
+     *
+     * @param id Unique step id for memoization.
+     * @param events An array of event payload objects.
+     *
+     */
+    fun sendEvent(
+        id: String,
+        events: Array<InngestEvent>,
+    ) {
+        val hashedId = state.getHashFromId(id)
+
+        try {
+            // If this doesn't throw an error, it's null and that's what is expected
+            val stepState = state.getState<Any?>(hashedId)
+            if (stepState != null) {
+                throw Exception("step state expected sleep, got something else")
+            }
+            return
+        } catch (e: StateNotFound) {
+            val response = CommHandler.sendEvent<SendEventsResponse>(events)
+            throw StepInterruptSendEventException(id, hashedId, response!!.ids)
         }
     }
 }

--- a/inngest-core/src/main/kotlin/com/inngest/Step.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Step.kt
@@ -113,9 +113,11 @@ class Step(val state: State) {
 
         try {
             // If this doesn't throw an error, it's null and that's what is expected
+            // TODO - Get the event_ids that were sent and return it from this method
+            // event_ids are not in the data field but it's actually a separate one.
             val stepState = state.getState<Any?>(hashedId)
             if (stepState != null) {
-                throw Exception("step state expected sleep, got something else")
+                throw Exception("step state expected sendEvent, got something else")
             }
             return
         } catch (e: StateNotFound) {

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/InngestSingleton.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/InngestSingleton.java
@@ -1,6 +1,12 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.*;
+import com.inngest.CommHandler;
+import com.inngest.FunctionOptions;
+import com.inngest.FunctionTrigger;
+import com.inngest.InngestFunction;
+import com.inngest.FunctionContext;
+import com.inngest.Step;
+import com.inngest.InngestEvent;
 import kotlin.jvm.functions.Function2;
 
 import java.time.Duration;

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/InngestSingleton.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/InngestSingleton.java
@@ -5,17 +5,23 @@ import kotlin.jvm.functions.Function2;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 // NOTE: We probably don't need this singleton anymore
 // when revisiting the SDK's interface.
 public class InngestSingleton {
     private static CommHandler instance;
 
+    private static final String followUpEvent = "user.signup.completed";
+
     public static synchronized CommHandler getInstance() {
         if (instance == null) {
             FunctionTrigger fnTrigger = new FunctionTrigger("user-signup", null, null);
-            FunctionTrigger[] triggers = {fnTrigger};
-            FunctionOptions fnConfig = new FunctionOptions("fn-id-slug", "My function!", triggers);
+            FunctionOptions fnConfig = new FunctionOptions(
+                "fn-id-slug",
+                "My function!",
+                new FunctionTrigger[]{fnTrigger}
+            );
 
             Function2<FunctionContext, Step, HashMap<String, String>> handler = (ctx, step) -> {
                 int x = 10;
@@ -39,14 +45,30 @@ public class InngestSingleton {
 
                 step.run("last-step", () -> (res != null ? res.sum : 0) * add, Integer.class);
 
+                HashMap<String, String> data = new HashMap<String, String>() {{
+                    put("hello", "world");
+                }};
+                step.sendEvent("followup-event-id", new InngestEvent(followUpEvent, data));
+
                 return new HashMap<String, String>() {{
                     put("message", "cool - this finished running");
                 }};
             };
-            InngestFunction function = new InngestFunction(fnConfig, handler);
+
+            FunctionTrigger followupFnTrigger = new FunctionTrigger(followUpEvent, null, null);
+            FunctionOptions followupFnConfig = new FunctionOptions(
+                "fn-follow-up",
+                "Follow up function!",
+                new FunctionTrigger[]{followupFnTrigger}
+            );
+            Function2<FunctionContext, Step, LinkedHashMap<String, Object>> followupHandler = (ctx, step) -> {
+                System.out.println("-> follow up handler called " + ctx.getEvent().getName());
+                return ctx.getEvent().getData();
+            };
 
             HashMap<String, InngestFunction> functions = new HashMap<>();
-            functions.put("fn-id-slug", function);
+            functions.put("fn-id-slug", new InngestFunction(fnConfig, handler));
+            functions.put("fn-follow-up", new InngestFunction(followupFnConfig, followupHandler));
 
             instance = new CommHandler(functions);
         }

--- a/inngest-test-server/src/main/kotlin/com/inngest/App.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/App.kt
@@ -1,7 +1,11 @@
 package com.inngest.testserver
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.inngest.*
+import com.inngest.CommHandler
+import com.inngest.FunctionOptions
+import com.inngest.FunctionTrigger
+import com.inngest.InngestEvent
+import com.inngest.InngestFunction
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
@@ -53,7 +57,7 @@ data class Result(
     val sum: Int,
 )
 
-const val followUpEvent = "user.signup.completed"
+const val FOLLOW_UP_EVENT_NAME = "user.signup.completed"
 
 val fn =
     InngestFunction(
@@ -92,7 +96,7 @@ val fn =
 
         step.run("last-step") { res.sum.times(add) ?: 0 }
 
-        step.sendEvent("followup-event-id", InngestEvent(followUpEvent, data = hashMapOf("hello" to "world")))
+        step.sendEvent("followup-event-id", InngestEvent(FOLLOW_UP_EVENT_NAME, data = hashMapOf("hello" to "world")))
 
         hashMapOf("message" to "cool - this finished running")
     }
@@ -101,7 +105,7 @@ val fn2 =
         FunctionOptions(
             id = "fn-follow-up",
             name = "Follow up function!",
-            triggers = arrayOf(FunctionTrigger(event = followUpEvent)),
+            triggers = arrayOf(FunctionTrigger(event = FOLLOW_UP_EVENT_NAME)),
         ),
     ) { ctx, _ ->
         println("-> followup fn called $ctx.event.name")


### PR DESCRIPTION
Add support for [`step.sendEvent`](https://www.inngest.com/docs/reference/functions/step-send-event) to send events out.

Introduces a small refactor to the `CommHandler` http client to dry out API calls.