### PR TITLE
Add version to jar manifest and read at runtime for SDK version header

### DIFF
--- a/inngest-core/build.gradle.kts
+++ b/inngest-core/build.gradle.kts
@@ -1,4 +1,8 @@
+import java.io.FileOutputStream
+import java.util.Properties
+
 description = "Inngest SDK"
+version = "0.0.1-SNAPSHOT"
 
 plugins { id("org.jetbrains.kotlin.jvm") version "1.9.10" }
 
@@ -15,6 +19,31 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     testImplementation(kotlin("test"))
+}
+
+val generatedVersionDir = "$buildDir/generated-version"
+
+sourceSets {
+    main {
+        kotlin {
+            output.dir(generatedVersionDir)
+        }
+    }
+}
+
+tasks.register("generateVersionProperties") {
+    doLast {
+        val propertiesFile = file("$generatedVersionDir/version.properties")
+        propertiesFile.parentFile.mkdirs()
+        val properties = Properties()
+        properties.setProperty("version", "$version")
+        val out = FileOutputStream(propertiesFile)
+        properties.store(out, null)
+    }
+}
+
+tasks.named("processResources") {
+    dependsOn("generateVersionProperties")
 }
 
 tasks.named<Test>("test") {

--- a/inngest-core/build.gradle.kts
+++ b/inngest-core/build.gradle.kts
@@ -1,6 +1,3 @@
-import java.io.FileOutputStream
-import java.util.Properties
-
 description = "Inngest SDK"
 version = "0.0.1-SNAPSHOT"
 
@@ -21,16 +18,6 @@ dependencies {
     testImplementation(kotlin("test"))
 }
 
-val generatedVersionDir = "$buildDir/generated-version"
-
-sourceSets {
-    main {
-        kotlin {
-            output.dir(generatedVersionDir)
-        }
-    }
-}
-
 tasks.jar {
     manifest {
         attributes(
@@ -40,21 +27,6 @@ tasks.jar {
             ),
         )
     }
-}
-
-tasks.register("generateVersionProperties") {
-    doLast {
-        val propertiesFile = file("$generatedVersionDir/version.properties")
-        propertiesFile.parentFile.mkdirs()
-        val properties = Properties()
-        properties.setProperty("version", "$version")
-        val out = FileOutputStream(propertiesFile)
-        properties.store(out, null)
-    }
-}
-
-tasks.named("processResources") {
-    dependsOn("generateVersionProperties")
 }
 
 tasks.named<Test>("test") {

--- a/inngest-core/build.gradle.kts
+++ b/inngest-core/build.gradle.kts
@@ -31,6 +31,17 @@ sourceSets {
     }
 }
 
+tasks.jar {
+    manifest {
+        attributes(
+            mapOf(
+                "Implementation-Title" to project.name,
+                "Implementation-Version" to project.version,
+            ),
+        )
+    }
+}
+
 tasks.register("generateVersionProperties") {
     doLast {
         val propertiesFile = file("$generatedVersionDir/version.properties")

--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -50,7 +50,7 @@ class CommHandler(val functions: HashMap<String, InngestFunction>) {
         return mapOf(
             "Content-Type" to "application/json",
             // TODO - Get this from the build
-            "x-inngest-sdk" to "inngest-kt:${Version().getVersion()}",
+            "x-inngest-sdk" to "inngest-kt:${Version.getVersion()}",
             // TODO - Pull this from options
             "x-inngest-framework" to "ktor",
         )
@@ -123,7 +123,7 @@ class CommHandler(val functions: HashMap<String, InngestFunction>) {
                 framework = "ktor",
                 sdk = "kotlin",
                 url = "http://localhost:8080/api/inngest",
-                v = Version().getVersion(),
+                v = Version.getVersion(),
                 functions = getFunctionConfigs(),
             )
         val jsonRequestBody = Klaxon().toJsonString(requestPayload)
@@ -163,7 +163,7 @@ class CommHandler(val functions: HashMap<String, InngestFunction>) {
                 framework = "ktor",
                 sdk = "kotlin",
                 url = "http://localhost:8080/api/inngest",
-                v = Version().getVersion(),
+                v = Version.getVersion(),
                 functions = getFunctionConfigs(),
             )
         return Klaxon().toJsonString(requestPayload)

--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -50,7 +50,7 @@ class CommHandler(val functions: HashMap<String, InngestFunction>) {
         return mapOf(
             "Content-Type" to "application/json",
             // TODO - Get this from the build
-            "x-inngest-sdk" to "inngest-kt:v0.0.1",
+            "x-inngest-sdk" to "inngest-kt:${Version().getVersion()}",
             // TODO - Pull this from options
             "x-inngest-framework" to "ktor",
         )
@@ -123,7 +123,7 @@ class CommHandler(val functions: HashMap<String, InngestFunction>) {
                 framework = "ktor",
                 sdk = "kotlin",
                 url = "http://localhost:8080/api/inngest",
-                v = "0.0.1",
+                v = Version().getVersion(),
                 functions = getFunctionConfigs(),
             )
         val jsonRequestBody = Klaxon().toJsonString(requestPayload)
@@ -163,7 +163,7 @@ class CommHandler(val functions: HashMap<String, InngestFunction>) {
                 framework = "ktor",
                 sdk = "kotlin",
                 url = "http://localhost:8080/api/inngest",
-                v = "0.0.1",
+                v = Version().getVersion(),
                 functions = getFunctionConfigs(),
             )
         return Klaxon().toJsonString(requestPayload)

--- a/inngest-core/src/main/kotlin/com/inngest/Version.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Version.kt
@@ -1,14 +1,9 @@
 package com.inngest
 
-import java.util.Properties
-
-// TODO should this be a singleton?
 class Version() {
-    private val versionProperties = Properties()
+    companion object {
+        private val version: String = Version::class.java.getPackage().implementationVersion
 
-    init {
-        versionProperties.load(this.javaClass.getResourceAsStream("/version.properties"))
+        fun getVersion(): String = version
     }
-
-    fun getVersion(): String = versionProperties.getProperty("version") ?: "missing-version"
 }

--- a/inngest-core/src/main/kotlin/com/inngest/Version.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Version.kt
@@ -1,0 +1,14 @@
+package com.inngest
+
+import java.util.Properties
+
+// TODO should this be a singleton?
+class Version() {
+    private val versionProperties = Properties()
+
+    init {
+        versionProperties.load(this.javaClass.getResourceAsStream("/version.properties"))
+    }
+
+    fun getVersion(): String = versionProperties.getProperty("version") ?: "missing-version"
+}

--- a/inngest-spring-boot-demo/build.gradle.kts
+++ b/inngest-spring-boot-demo/build.gradle.kts
@@ -33,4 +33,3 @@ dependencyManagement {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
-


### PR DESCRIPTION
Add version to the jar manifest and read from that to send the SDK version header

https://docs.gradle.org/current/samples/sample_building_kotlin_libraries.html#customize_the_library_jar

https://stackoverflow.com/a/43065467

To avoid unnecessarily reading from the manifest file, we store the value in a companion object which
should have the effect of making it a singleton.

An alternative using java properties was considered based on https://stackoverflow.com/a/70088083, but
the jar manifest seems more appropriate
