### PR TITLE
Make version nullable in case implementationVersion can't be read from JAR

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/Version.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Version.kt
@@ -2,8 +2,8 @@ package com.inngest
 
 class Version() {
     companion object {
-        private val version: String = Version::class.java.getPackage().implementationVersion
+        private val version: String? = Version::class.java.getPackage().implementationVersion
 
-        fun getVersion(): String = version
+        fun getVersion(): String = version ?: "version-not-found"
     }
 }


### PR DESCRIPTION
currently running the server from IntelliJ isn't able to read the
version from the JAR (probably because IntelliJ doesn't build the jar
when running?), so add a fallback string

Running the server with gradle from command line or with the run buttons
in README.md (which are also gradle invocations) does read the version
correctly