### PR TITLE
Ignore intellij's project config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ gradle-app.setting
 # LSP generated
 **/.settings/
 **/bin/
+
+# Intellij
+.idea/


### PR DESCRIPTION
We could have it back later if it becomes this project's suggested/expected to use IDE.