### PR TITLE
Remove usage of Kotlin's `Function2` in the spring boot java app

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Function.kt
@@ -1,6 +1,7 @@
 package com.inngest
 
 import com.beust.klaxon.Json
+import java.util.function.BiFunction
 
 // IDEA: Use data classes
 data class FunctionOptions(
@@ -104,8 +105,13 @@ interface Function {
 // TODO: make this implement the Function interface
 open class InngestFunction(
     val config: FunctionOptions,
-    val handler: (ctx: FunctionContext, step: Step) -> kotlin.Any?,
+    val handler: (ctx: FunctionContext, step: Step) -> Any?,
 ) {
+    constructor(config: FunctionOptions, handler: BiFunction<FunctionContext, Step, out Any>, a: Int) : this(
+        config,
+        handler.toKotlin(),
+    )
+
     fun id() = config.id
 
     // TODO - Validate options and trigger

--- a/inngest-core/src/main/kotlin/com/inngest/LambdaHelpers.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/LambdaHelpers.kt
@@ -1,0 +1,5 @@
+package com.inngest
+
+import java.util.function.BiFunction
+
+internal fun <A, B, C> BiFunction<A, B, C>.toKotlin(): (A, B) -> C = { a, b -> this.apply(a, b) }

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/DemoConfiguration.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/DemoConfiguration.java
@@ -3,13 +3,12 @@ package com.inngest.springbootdemo;
 
 import com.inngest.*;
 import com.inngest.springboot.InngestConfiguration;
-import kotlin.jvm.functions.Function2;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.LinkedHashMap;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.function.BiFunction;
 
 @Configuration
 public class DemoConfiguration extends InngestConfiguration {
@@ -21,7 +20,7 @@ public class DemoConfiguration extends InngestConfiguration {
         FunctionTrigger[] triggers = {fnTrigger};
         FunctionOptions fnConfig = new FunctionOptions("fn-id-slug", "My function!", triggers);
 
-        Function2<FunctionContext, Step, HashMap<String, String>> handler = (ctx, step) -> {
+        BiFunction<FunctionContext, Step, HashMap<String, String>> handler = (ctx, step) -> {
             int x = 10;
 
             System.out.println("-> handler called " + ctx.getEvent().getName());
@@ -62,14 +61,14 @@ public class DemoConfiguration extends InngestConfiguration {
             "Follow up function!",
             new FunctionTrigger[]{followupFnTrigger}
         );
-        Function2<FunctionContext, Step, LinkedHashMap<String, Object>> followupHandler = (ctx, step) -> {
+        BiFunction<FunctionContext, Step, LinkedHashMap<String, Object>> followupHandler = (ctx, step) -> {
             System.out.println("-> follow up handler called " + ctx.getEvent().getName());
             return ctx.getEvent().getData();
         };
 
         HashMap<String, InngestFunction> functions = new HashMap<>();
-        functions.put("fn-id-slug", new InngestFunction(fnConfig, handler));
-        functions.put("fn-follow-up", new InngestFunction(followupFnConfig, followupHandler));
+        functions.put("fn-id-slug", new InngestFunction(fnConfig, handler,1));
+        functions.put("fn-follow-up", new InngestFunction(followupFnConfig, followupHandler,2));
 
         return functions;
     }


### PR DESCRIPTION
Addressing: https://github.com/inngest/inngest-kt/pull/28#discussion_r1501884358
`InngestFunction` now has a second constructor that handles passing a Java lambda.

Solution Based on:
https://stackoverflow.com/questions/55057353/converting-java-util-function-function-to-kotlins-functional-interface-type