### PR TITLE
Use configured baseUrl and eventKey for sending events

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/Environment.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Environment.kt
@@ -21,7 +21,7 @@ object Environment {
 
     fun inngestEventKey(key: String? = null): String {
         if (key != null) return key
-        return System.getenv(InngestSystem.EventKey.value) ?: ""
+        return System.getenv(InngestSystem.EventKey.value) ?: "NO_EVENT_KEY_SET"
     }
 
     fun inngestSigningKey(

--- a/inngest-core/src/main/kotlin/com/inngest/Inngest.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Inngest.kt
@@ -36,7 +36,6 @@ class Inngest
         }
 
         internal inline fun <reified T> sendEvent(payload: Any): T? {
-            val eventKey = "test"
-            return send("http://localhost:8288/e/$eventKey", payload)
+            return send("$baseUrl/e/$eventKey", payload)
         }
     }

--- a/inngest-core/src/test/kotlin/com/inngest/EnvironmentTest.kt
+++ b/inngest-core/src/test/kotlin/com/inngest/EnvironmentTest.kt
@@ -21,7 +21,7 @@ internal class EnvironmentTest {
     // EventKey
     @Test
     fun `test inngestEventKey`() {
-        assertEquals("", Environment.inngestEventKey())
+        assertEquals("NO_EVENT_KEY_SET", Environment.inngestEventKey())
     }
 
     @Test


### PR DESCRIPTION
`NO_EVENT_KEY_SET` matches the JS SDK
https://github.com/inngest/inngest-js/blob/1b9f101ca6cd310e429cebcf8bceaf2faf309624/packages/inngest/src/components/Inngest.ts#L312
https://github.com/inngest/inngest-js/blob/1b9f101ca6cd310e429cebcf8bceaf2faf309624/packages/inngest/src/helpers/consts.ts#L151

Alternatively, we could use `test` like https://github.com/darwin67/inngest-ex/blob/5785538f13d4c1d7c970c65f83eefd89a0d8de09/lib/inngest/config.ex#L115-L117