### PR TITLE
Improves the retry behavior of functions by returning retry headers

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -88,7 +88,7 @@ class CommHandler(
             )
         } catch (e: Exception) {
             val retryDecision = RetryDecision.fromException(e)
-            val statusCode = if (retryDecision.shouldRetry) ResultStatusCode.Error else ResultStatusCode.BadRequest
+            val statusCode = if (retryDecision.shouldRetry) ResultStatusCode.Error else ResultStatusCode.NonRetriableError
 
             val err =
                 CommError(

--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -88,7 +88,7 @@ class CommHandler(
             )
         } catch (e: Exception) {
             val retryDecision = RetryDecision.fromException(e)
-            val statusCode = if (retryDecision.shouldRetry) ResultStatusCode.Error else ResultStatusCode.NonRetriableError
+            val statusCode = if (retryDecision.shouldRetry) ResultStatusCode.RetriableError else ResultStatusCode.NonRetriableError
 
             val err =
                 CommError(

--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -87,6 +87,9 @@ class CommHandler(
                 headers = headers,
             )
         } catch (e: Exception) {
+            val retryDecision = RetryDecision.fromException(e)
+            val statusCode = if (retryDecision.shouldRetry) ResultStatusCode.Error else ResultStatusCode.BadRequest
+
             val err =
                 CommError(
                     name = e.toString(),
@@ -95,8 +98,8 @@ class CommHandler(
                 )
             return CommResponse(
                 body = Klaxon().toJsonString(err),
-                statusCode = ResultStatusCode.Error,
-                headers = headers,
+                statusCode = statusCode,
+                headers = headers.plus(retryDecision.headers),
             )
         }
     }

--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -103,7 +103,7 @@ class CommHandler(
 
     private fun getFunctionConfigs(): List<FunctionConfig> {
         val configs: MutableList<FunctionConfig> = mutableListOf()
-        functions.forEach { entry -> configs.add(entry.value.getConfig()) }
+        functions.forEach { entry -> configs.add(entry.value.getFunctionConfig()) }
         return configs
     }
 

--- a/inngest-core/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Function.kt
@@ -33,6 +33,7 @@ enum class OpCode {
 enum class ResultStatusCode(val code: Int, val message: String) {
     StepComplete(206, "Step Complete"),
     FunctionComplete(200, "Function Complete"),
+    BadRequest(400, "Bad Request"),
     Error(500, "Function Error"),
 }
 

--- a/inngest-core/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Function.kt
@@ -192,7 +192,7 @@ open class InngestFunction(
         }
     }
 
-    fun getConfig(): FunctionConfig {
+    fun getFunctionConfig(): FunctionConfig {
         return FunctionConfig(
             id = config.id,
             name = config.name,

--- a/inngest-core/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Function.kt
@@ -34,7 +34,7 @@ enum class ResultStatusCode(val code: Int, val message: String) {
     StepComplete(206, "Step Complete"),
     FunctionComplete(200, "Function Complete"),
     NonRetriableError(400, "Bad Request"),
-    Error(500, "Function Error"),
+    RetriableError(500, "Function Error"),
 }
 
 abstract class StepOp(
@@ -188,7 +188,7 @@ open class InngestFunction(
                 id = e.hashedId,
                 name = e.id,
                 op = OpCode.StepStateFailed,
-                statusCode = ResultStatusCode.Error,
+                statusCode = ResultStatusCode.RetriableError,
             )
         }
     }

--- a/inngest-core/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Function.kt
@@ -33,7 +33,7 @@ enum class OpCode {
 enum class ResultStatusCode(val code: Int, val message: String) {
     StepComplete(206, "Step Complete"),
     FunctionComplete(200, "Function Complete"),
-    BadRequest(400, "Bad Request"),
+    NonRetriableError(400, "Bad Request"),
     Error(500, "Function Error"),
 }
 

--- a/inngest-core/src/main/kotlin/com/inngest/NonRetriableError.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/NonRetriableError.kt
@@ -1,0 +1,5 @@
+package com.inngest
+
+open class NonRetriableError
+    @JvmOverloads
+    constructor(message: String, cause: Throwable? = null) : RuntimeException(message, cause)

--- a/inngest-core/src/main/kotlin/com/inngest/RetryAfterError.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/RetryAfterError.kt
@@ -1,0 +1,21 @@
+package com.inngest
+
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+open class RetryAfterError
+    @JvmOverloads
+    constructor(message: String, retryAfter: Any, cause: Throwable? = null) :
+    RuntimeException(message, cause) {
+        var retryAfter: String =
+            when (retryAfter) {
+                is ZonedDateTime -> retryAfter.format(DateTimeFormatter.ISO_INSTANT)
+
+                is Int -> (retryAfter / 1000).toString()
+
+                // TODO: Add ms parsing: https://github.com/vercel/ms
+                is String -> (retryAfter.toInt() / 1000).toString()
+
+                else -> throw IllegalArgumentException("Invalid retryAfter type: ${retryAfter::class.simpleName}")
+            }
+    }

--- a/inngest-core/src/main/kotlin/com/inngest/RetryDecision.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/RetryDecision.kt
@@ -1,0 +1,21 @@
+package com.inngest
+
+internal data class RetryDecision(val shouldRetry: Boolean, val headers: Map<String, String>) {
+    companion object {
+        internal fun fromException(exception: Exception): RetryDecision =
+            when (exception) {
+                is RetryAfterError ->
+                    RetryDecision(
+                        true,
+                        mapOf(InngestHeaderKey.RetryAfter.value to exception.retryAfter, noRetryFalse),
+                    )
+
+                is NonRetriableError -> RetryDecision(false, mapOf(InngestHeaderKey.NoRetry.value to "true"))
+
+                // Any other error should have the default retry behavior.
+                else -> RetryDecision(true, mapOf(noRetryFalse))
+            }
+    }
+}
+
+private val noRetryFalse = InngestHeaderKey.NoRetry.value to "false"

--- a/inngest-core/src/test/kotlin/com/inngest/RetryAfterErrorTest.kt
+++ b/inngest-core/src/test/kotlin/com/inngest/RetryAfterErrorTest.kt
@@ -1,0 +1,28 @@
+package com.inngest
+
+import java.time.ZonedDateTime
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class RetryAfterErrorTest {
+    @Test
+    fun `should return retryAfter in seconds when an integer is passed`() {
+        val retryAfter = 5000
+        val retryAfterError = RetryAfterError("Error", retryAfter)
+        assertEquals("5", retryAfterError.retryAfter)
+    }
+
+    @Test
+    fun `should return retryAfter in seconds when an string is passed`() {
+        val retryAfter = "5000"
+        val retryAfterError = RetryAfterError("Error", retryAfter)
+        assertEquals("5", retryAfterError.retryAfter)
+    }
+
+    @Test
+    fun `should return retryAfter as an ISO string when a ZonedDateTime is passed`() {
+        val retryAfter = ZonedDateTime.parse("2021-08-25T00:00:00Z")
+        val retryAfterError = RetryAfterError("Error", retryAfter)
+        assertEquals("2021-08-25T00:00:00Z", retryAfterError.retryAfter)
+    }
+}

--- a/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
+++ b/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
@@ -39,7 +39,10 @@ public abstract class InngestController {
         try {
             CommResponse response = commHandler.callFunction(functionId, body);
 
-            return ResponseEntity.status(response.getStatusCode().getCode()).headers(getHeaders())
+            HttpHeaders headers = new HttpHeaders();
+            response.getHeaders().forEach(headers::add);
+
+            return ResponseEntity.status(response.getStatusCode().getCode()).headers(headers)
                 .body(response.getBody());
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -11,13 +11,21 @@ public class DemoTestConfiguration extends InngestConfiguration {
     @Override
     protected HashMap<String, InngestFunction> functions() {
         HashMap<String, InngestFunction> functions = new HashMap<>();
-        functions.put("no-step-fn", InngestFunctionTestHelpers.emptyStepFunction());
-        functions.put("sleep-fn", InngestFunctionTestHelpers.sleepStepFunction());
-        functions.put("two-steps-fn", InngestFunctionTestHelpers.twoStepsFunction());
-        functions.put("wait-for-event-fn", InngestFunctionTestHelpers.waitForEventFunction());
-        functions.put("send-fn", InngestFunctionTestHelpers.sendEventFunction());
+        addInngestFunction(functions, InngestFunctionTestHelpers.emptyStepFunction());
+        addInngestFunction(functions, InngestFunctionTestHelpers.sleepStepFunction());
+        addInngestFunction(functions, InngestFunctionTestHelpers.twoStepsFunction());
+        addInngestFunction(functions, InngestFunctionTestHelpers.waitForEventFunction());
+        addInngestFunction(functions, InngestFunctionTestHelpers.sendEventFunction());
+        addInngestFunction(functions, InngestFunctionTestHelpers.nonRetriableErrorFunction());
+        addInngestFunction(functions, InngestFunctionTestHelpers.retriableErrorFunction());
 
         return functions;
+    }
+
+    private static void addInngestFunction(
+        HashMap<String, InngestFunction> functions,
+        InngestFunction function) {
+        functions.put(function.getConfig().getId(), function);
     }
 
     @Override

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/ErrorsInStepsIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/ErrorsInStepsIntegrationTest.java
@@ -1,0 +1,71 @@
+package com.inngest.springbootdemo;
+
+import com.inngest.CommHandler;
+import com.inngest.Inngest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
+class ErrorsInStepsIntegrationTest {
+    @BeforeAll
+    static void setup(@Autowired CommHandler handler) {
+        handler.register();
+    }
+
+    @Autowired
+    private DevServerComponent devServer;
+
+    static int sleepTime = 10000;
+
+    @Autowired
+    private Inngest client;
+
+    @Test
+    void testNonRetriableShouldFail() throws Exception {
+        String eventId = InngestFunctionTestHelpers.sendEvent(client, "test/non.retriable").first();
+
+        Thread.sleep(sleepTime);
+
+        RunEntry<Object> run = devServer.runsByEvent(eventId).first();
+        LinkedHashMap<String, String> output = (LinkedHashMap<String, String>) run.getOutput();
+
+        assertEquals(run.getStatus(), "Failed");
+        assertNotNull(run.getEnded_at());
+        assert output.get("name").contains("NonRetriableError");
+        assert output.get("stack").contains("lambda$nonRetriableErrorFunction");
+        assertEquals(output.get("message"), "something fatally went wrong");
+    }
+
+
+    @Test
+    void testRetriableShouldSucceedAfterFirstAttempt() throws Exception {
+        String eventId = InngestFunctionTestHelpers.sendEvent(client, "test/retriable").first();
+
+        Thread.sleep(5000);
+
+        RunEntry<Object> run1 = devServer.runsByEvent(eventId).first();
+
+        assertEquals(run1.getStatus(), "Running");
+
+        // The second attempt should succeed, so we wait for the second run to finish.
+        Thread.sleep(15000);
+
+        RunEntry<Object> run2 = devServer.runsByEvent(eventId).first();
+
+        assertEquals(run2.getStatus(), "Completed");
+        assertNotNull(run2.getEnded_at(), "Completed");
+        assertNotNull(run2.getOutput(), "Success");
+    }
+
+
+}


### PR DESCRIPTION
- Add support for retriable/non-retriable errors in steps by returning `X-Inngest-No-Retry` and `Retry-After` headers as required.
- Improve how we are creating functions in tests by DRYing out the ids.
- Add tests cases for retriable/non-retriable functions.