### PR TITLE
Add hashed signing key as bearer token for /fn/register

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -110,12 +110,13 @@ class CommHandler(
 
     fun register(): String {
         val registrationUrl = "${config.baseUrl()}/fn/register"
+        // TODO use name from ServeConfig, framework from adapter, serveOrigin from ServeConfig
         val requestPayload =
             RegistrationRequestPayload(
-                appName = "my-app", // TODO use name from ServeConfig
-                framework = "ktor", // TODO use framework from adapter
+                appName = "my-app",
+                framework = "ktor",
                 sdk = "inngest-kt",
-                url = "http://localhost:8080/api/inngest", // TODO use ServeConfig.serveOrigin?
+                url = "http://localhost:8080/api/inngest",
                 v = Version.getVersion(),
                 functions = getFunctionConfigs(),
             )
@@ -150,7 +151,7 @@ class CommHandler(
             RegistrationRequestPayload(
                 appName = "my-app",
                 framework = "ktor",
-                sdk = "kotlin",
+                sdk = "inngest-kt",
                 url = "http://localhost:8080/api/inngest",
                 v = Version.getVersion(),
                 functions = getFunctionConfigs(),

--- a/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
@@ -1,0 +1,36 @@
+package com.inngest.signingkey
+
+import com.inngest.RequestHeaders
+import java.security.MessageDigest
+
+val SIGNING_KEY_REGEX = Regex("""(?<prefix>^signkey-[\w]+-)(?<key>.*)""")
+
+// https://www.baeldung.com/sha-256-hashing-java
+
+/**
+ * Takes a signing key in the form "signkey-<env>-<key>" and returns "signkey-<env>-<hex-encoded sha256 of key>"
+ *
+ * @param signingKey signing key in the form "signkey-<env>-<key>"
+ * @return the hashed signing key in the form "signkey-<env>-<hex-encoded sha256 of key>"
+ * @throws InvalidSigningKeyException If signingKey is not in the form "signkey-<env>-<key>"
+ */
+private fun hashedSigningKey(signingKey: String): String {
+    val matchResult = SIGNING_KEY_REGEX.matchEntire(signingKey) ?: throw InvalidSigningKeyException()
+
+    // We aggressively assert non null here because if `matchEntire` had failed (and thus these capture groups didn't
+    // exist), we would have already thrown an exception
+    val prefix = matchResult.groups["prefix"]!!.value
+    val key = matchResult.groups["key"]!!.value
+
+    val sha256MessageDigest = MessageDigest.getInstance("SHA-256") // not thread safe, get new instance every time
+    val hashedKey = sha256MessageDigest.digest(key.toByteArray(Charsets.UTF_8))
+    // https://gist.github.com/lovubuntu/164b6b9021f5ba54cefc67f60f7a1a25
+    val hexEncodedHashedKey = hashedKey.fold(StringBuilder()) { sb, it -> sb.append("%02x".format(it)) }.toString()
+
+    return "$prefix$hexEncodedHashedKey"
+}
+
+fun getAuthorizationHeader(signingKey: String): RequestHeaders {
+    val hashedSigningKey = hashedSigningKey(signingKey)
+    return mapOf("Authorization" to "Bearer $hashedSigningKey")
+}

--- a/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
@@ -13,6 +13,7 @@ val SIGNING_KEY_REGEX = Regex("""(?<prefix>^signkey-[\w]+-)(?<key>.*)""")
  * @return the hashed signing key in the form "signkey-<env>-<hex-encoded sha256 of key>"
  * @throws InvalidSigningKeyException If signingKey is not in the form "signkey-<env>-<key>"
  */
+@OptIn(ExperimentalStdlibApi::class)
 private fun hashedSigningKey(signingKey: String): String {
     val matchResult = SIGNING_KEY_REGEX.matchEntire(signingKey) ?: throw InvalidSigningKeyException()
 
@@ -23,8 +24,7 @@ private fun hashedSigningKey(signingKey: String): String {
 
     val sha256MessageDigest = MessageDigest.getInstance("SHA-256") // not thread safe, get new instance every time
     val hashedKey = sha256MessageDigest.digest(key.toByteArray(Charsets.UTF_8))
-    // https://gist.github.com/lovubuntu/164b6b9021f5ba54cefc67f60f7a1a25
-    val hexEncodedHashedKey = hashedKey.fold(StringBuilder()) { sb, it -> sb.append("%02x".format(it)) }.toString()
+    val hexEncodedHashedKey = hashedKey.toHexString()
 
     return "$prefix$hexEncodedHashedKey"
 }

--- a/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
@@ -24,11 +24,12 @@ private fun hashedSigningKey(signingKey: String): String {
     val key = matchResult.groups["key"]!!.value
 
     val sha256MessageDigest = MessageDigest.getInstance("SHA-256") // not thread safe, get new instance every time
-    val hashedKey = try {
-        sha256MessageDigest.digest(key.hexToByteArray())
-    } catch (e: NumberFormatException) {
-        throw InvalidSigningKeyException()
-    }
+    val hashedKey =
+        try {
+            sha256MessageDigest.digest(key.hexToByteArray())
+        } catch (e: NumberFormatException) {
+            throw InvalidSigningKeyException()
+        }
     val hexEncodedHashedKey = hashedKey.toHexString()
 
     return "$prefix$hexEncodedHashedKey"

--- a/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
@@ -1,15 +1,16 @@
 package com.inngest.signingkey
 
 import com.inngest.RequestHeaders
+import java.lang.NumberFormatException
 import java.security.MessageDigest
 
 val SIGNING_KEY_REGEX = Regex("""(?<prefix>^signkey-[\w]+-)(?<key>.*)""")
 
 /**
- * Takes a signing key in the form "signkey-<env>-<key>" and returns "signkey-<env>-<hex-encoded sha256 of key>"
+ * Takes a signing key in the form "signkey-<env>-<hex-encoded key>" and returns "signkey-<env>-<hex-encoded sha256 of key>"
  * Inspired by https://www.baeldung.com/sha-256-hashing-java
  *
- * @param signingKey signing key in the form "signkey-<env>-<key>"
+ * @param signingKey signing key in the form "signkey-<env>-<hex-encoded key>"
  * @return the hashed signing key in the form "signkey-<env>-<hex-encoded sha256 of key>"
  * @throws InvalidSigningKeyException If signingKey is not in the form "signkey-<env>-<key>"
  */
@@ -23,7 +24,11 @@ private fun hashedSigningKey(signingKey: String): String {
     val key = matchResult.groups["key"]!!.value
 
     val sha256MessageDigest = MessageDigest.getInstance("SHA-256") // not thread safe, get new instance every time
-    val hashedKey = sha256MessageDigest.digest(key.toByteArray(Charsets.UTF_8))
+    val hashedKey = try {
+        sha256MessageDigest.digest(key.hexToByteArray())
+    } catch (e: NumberFormatException) {
+        throw InvalidSigningKeyException()
+    }
     val hexEncodedHashedKey = hashedKey.toHexString()
 
     return "$prefix$hexEncodedHashedKey"

--- a/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/signingkey/BearerToken.kt
@@ -5,10 +5,9 @@ import java.security.MessageDigest
 
 val SIGNING_KEY_REGEX = Regex("""(?<prefix>^signkey-[\w]+-)(?<key>.*)""")
 
-// https://www.baeldung.com/sha-256-hashing-java
-
 /**
  * Takes a signing key in the form "signkey-<env>-<key>" and returns "signkey-<env>-<hex-encoded sha256 of key>"
+ * Inspired by https://www.baeldung.com/sha-256-hashing-java
  *
  * @param signingKey signing key in the form "signkey-<env>-<key>"
  * @return the hashed signing key in the form "signkey-<env>-<hex-encoded sha256 of key>"

--- a/inngest-core/src/main/kotlin/com/inngest/signingkey/InvalidSigningKeyException.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/signingkey/InvalidSigningKeyException.kt
@@ -1,0 +1,3 @@
+package com.inngest.signingkey
+
+class InvalidSigningKeyException : Throwable("signing key does not match expected format")

--- a/inngest-core/src/test/kotlin/com/inngest/signingkey/BearerTokenKtTest.kt
+++ b/inngest-core/src/test/kotlin/com/inngest/signingkey/BearerTokenKtTest.kt
@@ -1,7 +1,7 @@
 package com.inngest.signingkey
 
-import kotlin.test.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class BearerTokenKtTest {

--- a/inngest-core/src/test/kotlin/com/inngest/signingkey/BearerTokenKtTest.kt
+++ b/inngest-core/src/test/kotlin/com/inngest/signingkey/BearerTokenKtTest.kt
@@ -1,0 +1,40 @@
+package com.inngest.signingkey
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BearerTokenKtTest {
+    @Test
+    fun `test invalid signing key format`() {
+        assertThrows<InvalidSigningKeyException> {
+            getAuthorizationHeader("signke-prod-blah")
+        }
+    }
+
+    @Test
+    fun `builds authorization header with bearer token for prod environment`() {
+        val authorizationHeader = getAuthorizationHeader("signkey-prod-8fjau3mn")
+        assertEquals(
+            "Authorization",
+            authorizationHeader.keys.first(),
+        )
+        assertEquals(
+            "Bearer signkey-prod-3c8335d113497a3a0b3e6bc18c12bf59e3db1c964c9f66765f374f5f7b473ac7",
+            authorizationHeader.values.first(),
+        )
+    }
+
+    @Test
+    fun `builds authorization header with bearer token for non prod environment`() {
+        val authorizationHeader = getAuthorizationHeader("signkey-staging-8fjau3mn")
+        assertEquals(
+            "Authorization",
+            authorizationHeader.keys.first(),
+        )
+        assertEquals(
+            "Bearer signkey-staging-3c8335d113497a3a0b3e6bc18c12bf59e3db1c964c9f66765f374f5f7b473ac7",
+            authorizationHeader.values.first(),
+        )
+    }
+}

--- a/inngest-core/src/test/kotlin/com/inngest/signingkey/BearerTokenTest.kt
+++ b/inngest-core/src/test/kotlin/com/inngest/signingkey/BearerTokenTest.kt
@@ -1,13 +1,13 @@
 package com.inngest.signingkey
 
-import org.junit.jupiter.api.Assertions.*
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
 
 class BearerTokenKtTest {
     @Test
     fun `test invalid signing key format`() {
-        assertThrows<InvalidSigningKeyException> {
+        assertFailsWith<InvalidSigningKeyException> {
             getAuthorizationHeader("signke-prod-blah")
         }
     }

--- a/inngest-core/src/test/kotlin/com/inngest/signingkey/BearerTokenTest.kt
+++ b/inngest-core/src/test/kotlin/com/inngest/signingkey/BearerTokenTest.kt
@@ -13,27 +13,34 @@ class BearerTokenKtTest {
     }
 
     @Test
+    fun `test signing key is not a valid hex string`() {
+        assertFailsWith<InvalidSigningKeyException> {
+            getAuthorizationHeader("signkey-prod-8fjau3mn")
+        }
+    }
+
+    @Test
     fun `builds authorization header with bearer token for prod environment`() {
-        val authorizationHeader = getAuthorizationHeader("signkey-prod-8fjau3mn")
+        val authorizationHeader = getAuthorizationHeader("signkey-prod-12345678")
         assertEquals(
             "Authorization",
             authorizationHeader.keys.first(),
         )
         assertEquals(
-            "Bearer signkey-prod-3c8335d113497a3a0b3e6bc18c12bf59e3db1c964c9f66765f374f5f7b473ac7",
+            "Bearer signkey-prod-b2ed992186a5cb19f6668aade821f502c1d00970dfd0e35128d51bac4649916c",
             authorizationHeader.values.first(),
         )
     }
 
     @Test
     fun `builds authorization header with bearer token for non prod environment`() {
-        val authorizationHeader = getAuthorizationHeader("signkey-staging-8fjau3mn")
+        val authorizationHeader = getAuthorizationHeader("signkey-test-12345678")
         assertEquals(
             "Authorization",
             authorizationHeader.keys.first(),
         )
         assertEquals(
-            "Bearer signkey-staging-3c8335d113497a3a0b3e6bc18c12bf59e3db1c964c9f66765f374f5f7b473ac7",
+            "Bearer signkey-test-b2ed992186a5cb19f6668aade821f502c1d00970dfd0e35128d51bac4649916c",
             authorizationHeader.values.first(),
         )
     }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoControllerTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoControllerTest.java
@@ -24,6 +24,6 @@ public class DemoControllerTest {
             .andExpect(content().contentType("application/json"))
             .andExpect(header().string(InngestHeaderKey.Framework.getValue(), "springboot"))
             .andExpect(jsonPath("$.appName").value("my-app"))
-            .andExpect(jsonPath("$.sdk").value("kotlin"));
+            .andExpect(jsonPath("$.sdk").value("inngest-kt"));
     }
 }


### PR DESCRIPTION
- Add logic to create bearer token from signing key
Originally followed the spec here https://github.com/inngest/inngest/blob/main/docs/SDK_SPEC.md#414-requirements-when-sending-a-request,
but based on [examples in `inngestgo`](https://github.com/inngest/inngestgo/blob/5081aafecb1c7894ee70d35b7a2347a0c79887f2/signature.go#L78)
the non hashed key should also be a hex string.

Fixed this and copied test cases from https://github.com/inngest/inngestgo/blob/5081aafecb1c7894ee70d35b7a2347a0c79887f2/signature_test.go#L74-L78

- Use signing key as a bearer token when sending requests to Inngest in non dev environments
- Replace hardcoded registration URL. Other hardcoded URLs will be addressed later

Follow up PR will handle signature verification
