### PR TITLE
Fix serialization of Java objects in step results/errors

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/Comm.kt
@@ -3,6 +3,7 @@ package com.inngest
 import com.beust.klaxon.Json
 import com.beust.klaxon.Klaxon
 import com.inngest.signingkey.getAuthorizationHeader
+import com.fasterxml.jackson.databind.ObjectMapper
 import java.io.IOException
 
 data class ExecutionRequestPayload(
@@ -83,7 +84,7 @@ class CommHandler(
                 body = result.data
             }
             return CommResponse(
-                body = Klaxon().toJsonString(body),
+                body = parseRequestBody(body),
                 statusCode = result.statusCode,
                 headers = headers,
             )
@@ -98,11 +99,16 @@ class CommHandler(
                     stack = e.stackTrace.joinToString(separator = "\n"),
                 )
             return CommResponse(
-                body = Klaxon().toJsonString(err),
+                body = parseRequestBody(err),
                 statusCode = statusCode,
                 headers = headers.plus(retryDecision.headers),
             )
         }
+    }
+
+    private fun parseRequestBody(requestBody: Any?): String {
+        val mapper = ObjectMapper()
+        return mapper.writeValueAsString(requestBody)
     }
 
     private fun getFunctionConfigs(): List<FunctionConfig> {
@@ -133,7 +139,7 @@ class CommHandler(
 
         // TODO - Add headers to output
         val body: Map<String, Any?> = mapOf()
-        return Klaxon().toJsonString(body)
+        return parseRequestBody(body)
     }
 
     fun sync(): Result<InngestSyncResult> {
@@ -142,7 +148,7 @@ class CommHandler(
 
     fun introspect(): String {
         val requestPayload = getRegistrationRequestPayload()
-        return Klaxon().toJsonString(requestPayload)
+        return parseRequestBody(requestPayload)
     }
 
     private fun getRegistrationRequestPayload(): RegistrationRequestPayload {

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/Result.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/Result.java
@@ -1,12 +1,18 @@
 package com.inngest.springbootdemo;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public class Result {
-    @JsonProperty("sum")
-    public final int sum;
+@Getter
+@Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
+@NoArgsConstructor
+class Result {
+    int sum;
 
-    public Result(@JsonProperty("sum") int sum) {
+    Result(int sum) {
         this.sum = sum;
     }
 }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -14,6 +14,7 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, InngestFunctionTestHelpers.emptyStepFunction());
         addInngestFunction(functions, InngestFunctionTestHelpers.sleepStepFunction());
         addInngestFunction(functions, InngestFunctionTestHelpers.twoStepsFunction());
+        addInngestFunction(functions, InngestFunctionTestHelpers.customStepResultFunction());
         addInngestFunction(functions, InngestFunctionTestHelpers.waitForEventFunction());
         addInngestFunction(functions, InngestFunctionTestHelpers.sendEventFunction());
         addInngestFunction(functions, InngestFunctionTestHelpers.nonRetriableErrorFunction());

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/InngestFunctionTestHelpers.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/InngestFunctionTestHelpers.java
@@ -62,6 +62,29 @@ public class InngestFunctionTestHelpers {
         return new InngestFunction(fnConfig, handler);
     }
 
+    static InngestFunction customStepResultFunction() {
+        FunctionTrigger fnTrigger = new FunctionTrigger("test/custom.result.step");
+        FunctionTrigger[] triggers = {fnTrigger};
+        FunctionOptions fnConfig = new FunctionOptions("custom-result-fn", "Custom Result Function", triggers);
+
+        int count = 0;
+
+        BiFunction<FunctionContext, Step, Result> handler = (ctx, step) -> {
+            int step1 = step.run("step1", () -> count + 1, Integer.class);
+            int tmp1 = step1 + 1;
+
+            int step2 = step.run("step2", () -> tmp1 + 1, Integer.class);
+            int tmp2 = step2 + 1;
+
+            return step.run("cast-to-type-add-one", () -> {
+                System.out.println("-> running step 1!! " + tmp2);
+                return new Result(tmp2 + 1);
+            }, Result.class);
+        };
+
+        return new InngestFunction(fnConfig, handler);
+    }
+
     static InngestFunction waitForEventFunction() {
         FunctionTrigger fnTrigger = new FunctionTrigger("test/wait-for-event");
         FunctionTrigger[] triggers = {fnTrigger};

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/WaitForEventFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/WaitForEventFunctionIntegrationTest.java
@@ -43,7 +43,7 @@ class WaitForEventFunctionIntegrationTest {
 
         Thread.sleep(sleepTime);
 
-        RunEntry<Object> updatedRun = devServer.runById(run.getRun_id()).getData();
+        RunEntry<Object> updatedRun = devServer.runById(run.getRun_id(), Object.class).getData();
 
         assertEquals(updatedRun.getEvent_id(), eventId);
         assertEquals(updatedRun.getRun_id(), run.getRun_id());
@@ -65,7 +65,7 @@ class WaitForEventFunctionIntegrationTest {
 
         Thread.sleep(sleepTime);
 
-        RunEntry<String> updatedRun = devServer.<String>runById(run.getRun_id()).getData();
+        RunEntry<String> updatedRun = devServer.runById(run.getRun_id(), String.class).getData();
 
         assertEquals(updatedRun.getEvent_id(), eventId);
         assertEquals(updatedRun.getRun_id(), run.getRun_id());


### PR DESCRIPTION
Replaces Klaxon with jackson's `ObjectMapper` for serializing `callFunction` responses. Which means it's no longer required to have step/function results to be public classes with public properties only. That requirement was introduced here: https://github.com/inngest/inngest-kt/pull/19#issue-2152375082.

Ideally I think we want to use jackson as much as possible eventually removing klaxon since it's not Java friendly.