### PR TITLE
Validate signature header for incoming POST requests

### DIFF
--- a/inngest-core/src/main/kotlin/com/inngest/signingkey/SignatureVerification.kt
+++ b/inngest-core/src/main/kotlin/com/inngest/signingkey/SignatureVerification.kt
@@ -1,0 +1,67 @@
+package com.inngest.signingkey
+
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import java.time.Instant
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+const val HMAC_SHA256 = "HmacSHA256"
+
+// Implementation of this is inspired by the pure Java example from https://www.baeldung.com/java-hmac#hmac-using-jdk-apis
+@OptIn(ExperimentalStdlibApi::class)
+private fun computeHMAC(
+    algorithm: String,
+    data: String,
+    key: String,
+): String {
+    val secretKeySpec = SecretKeySpec(key.toByteArray(Charsets.UTF_8), algorithm)
+    val mac = Mac.getInstance(algorithm)
+    mac.init(secretKeySpec)
+    return mac.doFinal(data.toByteArray(Charsets.UTF_8)).toHexString()
+}
+
+internal fun signRequest(
+    requestBody: String,
+    timestamp: Long,
+    signingKey: String,
+): String {
+    return signRequest(requestBody, timestamp.toString(), signingKey)
+}
+
+private fun signRequest(
+    requestBody: String,
+    timestamp: String,
+    signingKey: String,
+): String {
+    val matchResult = SIGNING_KEY_REGEX.matchEntire(signingKey) ?: throw InvalidSigningKeyException()
+    val key = matchResult.groups["key"]!!.value
+    val message = requestBody + timestamp
+
+    return computeHMAC(HMAC_SHA256, message, key)
+}
+
+class InvalidSignatureHeaderException(message: String) : Throwable(message)
+
+class ExpiredSignatureHeaderException : Throwable("signature header has expired")
+
+const val FIVE_MINUTES_IN_SECONDS = 5L * 60
+
+fun validateSignature(
+    signatureHeader: String,
+    signingKey: String,
+    requestBody: String,
+): Boolean {
+    // TODO: Find a way to parse signatureHeader as URL params without constructing a full URL
+    val dummyUrl = "https://test.inngest.com/?$signatureHeader"
+    val url = dummyUrl.toHttpUrlOrNull() ?: throw InvalidSignatureHeaderException("signature header does not match expected format")
+    val timestamp = url.queryParameter("t")?.toLongOrNull() ?: throw InvalidSignatureHeaderException("timestamp is invalid")
+    val signature = url.queryParameter("s") ?: throw InvalidSignatureHeaderException("signature is invalid")
+
+    val fiveMinutesAgo = Instant.now().minusSeconds(FIVE_MINUTES_IN_SECONDS).epochSecond
+    if (timestamp < fiveMinutesAgo) {
+        throw ExpiredSignatureHeaderException()
+    }
+
+    val actualSignature = signRequest(requestBody, timestamp, signingKey)
+    return actualSignature == signature
+}

--- a/inngest-core/src/test/kotlin/com/inngest/signingkey/SignatureVerificationKtTest.kt
+++ b/inngest-core/src/test/kotlin/com/inngest/signingkey/SignatureVerificationKtTest.kt
@@ -1,0 +1,64 @@
+package com.inngest.signingkey
+
+import java.time.Instant
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SignatureVerificationKtTest {
+    val testBody = "hey!  if you're reading this come work with us: careers@inngest.com"
+    val testKey = "signkey-test-12345678"
+
+    @Test
+    fun `signRequest produces same signatures with different prefix keys`() {
+        val ts = 1709026298L
+        val a = signRequest(testBody, ts, "signkey-test-12345678")
+        val b = signRequest(testBody, ts, "signkey-prod-12345678")
+        val c = signRequest(testBody, ts, "signkey-staging-12345678")
+
+        assertEquals("3f1c811920eb25da7fa70e3ac484e32e93f01dbbca7c9ce2365f2062a3e10c26", a)
+        assertEquals(a, b)
+        assertEquals(a, c)
+    }
+
+    @Test
+    fun `fails with an invalid signature header`() {
+        assertFailsWith<InvalidSignatureHeaderException> {
+            validateSignature("lol", testKey, testBody)
+        }
+    }
+
+    @Test
+    fun `fails with an invalid timestamp`() {
+        assertFailsWith<InvalidSignatureHeaderException> {
+            validateSignature("t=what&s=yea", testKey, testBody)
+        }
+    }
+
+    @Test
+    fun `fails with an expired timestamp`() {
+        val now = Instant.now().epochSecond
+        val oneHourAgo = now - 60 * 60
+        assertFailsWith<ExpiredSignatureHeaderException> {
+            validateSignature("t=$oneHourAgo&s=yea", testKey, testBody)
+        }
+    }
+
+    @Test
+    fun `fails with a signing key that wasn't the one used to create the signature`() {
+        val now = Instant.now().epochSecond
+        val signature = signRequest(testBody, now, testKey)
+
+        assertFalse(validateSignature("t=$now&s=$signature", "signkey-test-badkey", testBody))
+    }
+
+    @Test
+    fun `succeeds if signature matches and timestamp is within a reasonable time`() {
+        val now = Instant.now().epochSecond
+        val signature = signRequest(testBody, now, testKey)
+
+        assertTrue(validateSignature("t=$now&s=$signature", testKey, testBody))
+    }
+}

--- a/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
+++ b/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
@@ -2,6 +2,7 @@ package com.inngest.springboot;
 
 import com.inngest.CommHandler;
 import com.inngest.CommResponse;
+import com.inngest.signingkey.SignatureVerificationKt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -33,10 +34,14 @@ public abstract class InngestController {
 
     @PostMapping()
     public ResponseEntity<String> handleRequest(
+        @RequestHeader(name = "X-Inngest-Signature", required = false) String signature,
+        @RequestHeader(name = "X-Inngest-Server-Kind", required = false) String serverKind,
         @RequestParam(name = "fnId") String functionId,
         @RequestBody String body
     ) {
         try {
+            SignatureVerificationKt.checkHeadersAndValidateSignature(signature, body, serverKind, commHandler.getConfig());
+
             CommResponse response = commHandler.callFunction(functionId, body);
 
             HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION
Implement various utility methods for validating inngest signatures

public
- checkHeadersAndValidateSignature: this can be called from code serving Inngest's request
  If this function finishes without an exception, the signature is valid

private/internal
- computing HMAC given a hex encoded key and body
- sign request body + timestamp using signing key in Inngest format (signkey-<env>-<key>)
- validate full signature header including format, timestamp within last 5 minutes, and signature itself


Add call to checkHeadersAndValidateSignature to spring boot adapter, currently only for POST
