### PR TITLE
Fix inngest.send. Add Event Builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class TranscodeVideo : InngestFunction() {
   <summary>Java (Coming soon)</summary>
 </details>
 
-## Defining configuration
+## Creating functions
 
 Define your function's configuration using the `config` method and the `InngestFunctionConfigBuilder` class.
 The `config` method must be overridden and an `id` is required. All options should are discoverable via
@@ -58,14 +58,37 @@ the builder class passed as the only argument to the `config` method.
   <summary>Kotlin</summary>
 
 ```kotlin
+import java.time.Duration
+
 class TranscodeVideo : InngestFunction() {
   override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder =
     builder
       .id("process-video")
       .name("Process video upload")
       .triggerEvent("media/video.uploaded")
+      .batchEvents(50, Duration.ofSeconds(30))
       .concurrency(10)
+}
+```
 
+</details>
+
+## Sending events (_triggering functions_)
+
+<details open>
+  <summary>Kotlin</summary>
+
+```kotlin
+import java.time.Duration
+
+class TranscodeVideo : InngestFunction() {
+  override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder =
+    builder
+      .id("process-video")
+      .name("Process video upload")
+      .triggerEvent("media/video.uploaded")
+      .batchEvents(50, Duration.ofSeconds(30))
+      .concurrency(10)
 }
 ```
 

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/App.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/App.kt
@@ -6,6 +6,7 @@ import com.inngest.ktor.*
 import io.ktor.server.application.*
 import io.ktor.server.engine.*
 import io.ktor.server.netty.*
+import io.ktor.server.response.*
 import io.ktor.server.routing.*
 
 data class Result(
@@ -26,8 +27,28 @@ fun Application.module() {
                 RestoreFromGlacier(),
                 ProcessUserSignup(),
                 TranscodeVideo(),
+                WeeklyCleanup(),
             ),
         )
+        get("/send") {
+            println("Sending event...")
+            try {
+                val event =
+                    InngestEvent(
+                        "delivery/process.requested",
+                        mapOf(
+                            "albumId" to "3d345a93-57c0-478b-a8ff-4d5f6a7df3b0",
+                            "title" to "The Teal Album",
+                        ),
+                    )
+                val res = inngest.send(event)
+                println(res)
+                call.respondText(res.ids.toString())
+            } catch (e: Exception) {
+                println(e)
+                call.respondText(e.toString())
+            }
+        }
     }
 }
 

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/ProcessAlbum.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/ProcessAlbum.kt
@@ -12,7 +12,6 @@ class ProcessAlbum : InngestFunction() {
             .id("ProcessAlbum")
             .name("Process Album!")
             .triggerEvent("delivery/process.requested")
-            .trigger(InngestFunctionTriggers.Cron("5 0 * 8 *"))
             .batchEvents(30, Duration.ofSeconds(10))
 
     override fun execute(

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/WeeklyCleanup.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/WeeklyCleanup.kt
@@ -1,0 +1,24 @@
+package com.inngest.testserver
+
+import com.inngest.*
+
+/**
+ * A demo function that runs on a given cron schedule
+ */
+class WeeklyCleanup : InngestFunction() {
+    override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder =
+        builder
+            .id("weekly-cleanup")
+            .name("Weekly cleanup")
+            .triggerCron("0 0 * * 0") // Every Sunday at midnight
+
+    override fun execute(
+        ctx: FunctionContext,
+        step: Step,
+    ): LinkedHashMap<String, Any> {
+        // this function will not have an event or events to utilize as it's a triggered on a cron schedule
+        // this is ideal for periodic jobs that don't fit an event-trigger pattern.
+
+        return linkedMapOf("hello" to true)
+    }
+}

--- a/inngest/src/main/kotlin/com/inngest/Event.kt
+++ b/inngest/src/main/kotlin/com/inngest/Event.kt
@@ -1,6 +1,9 @@
 package com.inngest
 
-data class Event(
+/**
+ * An internal class used for parsing events sent to Inngest functions
+ */
+internal data class Event(
     val id: String,
     val name: String,
     val data: LinkedHashMap<String, Any>,
@@ -9,7 +12,77 @@ data class Event(
     val v: Any? = null,
 )
 
-// data class EventAPIResponse(
-//    val ids: Array<String>,
-//    val status: String,
-// )
+/**
+ * Create an event to send to Inngest
+ */
+data class InngestEvent(
+    val id: String?,
+    val name: String,
+    val data: Any,
+    val user: Any?,
+    val ts: Long?,
+    val v: String? = null,
+)
+
+/**
+ * Construct a new Inngest Event via builder
+ */
+class InngestEventBuilder(
+    var id: String?,
+    var name: String?,
+    var data: Any?,
+    private var user: Any?,
+    private var ts: Long?,
+    private var v: String? = null,
+) {
+    fun id(id: String): InngestEventBuilder {
+        this.id = id
+        return this
+    }
+
+    fun name(name: String): InngestEventBuilder {
+        this.name = name
+        return this
+    }
+
+    fun data(data: Any): InngestEventBuilder {
+        this.data = data
+        return this
+    }
+
+    fun ts(ts: Long): InngestEventBuilder {
+        this.ts = ts
+        return this
+    }
+
+    fun v(v: String): InngestEventBuilder {
+        this.v = v
+        return this
+    }
+
+    fun build(): InngestEvent {
+        if (name == null) {
+            throw IllegalArgumentException("name is required")
+        }
+        if (data == null) {
+            throw IllegalArgumentException("data is required")
+        }
+        return InngestEvent(
+            id,
+            name!!,
+            data!!,
+            user,
+            ts,
+            v,
+        )
+    }
+}
+
+/**
+ * The response from the Inngest Event API including the ids of any event created
+ * in the order of which they were included in the request
+ */
+data class SendEventsResponse(
+    val ids: List<String>,
+    val status: Int,
+)

--- a/inngest/src/main/kotlin/com/inngest/Step.kt
+++ b/inngest/src/main/kotlin/com/inngest/Step.kt
@@ -5,26 +5,6 @@ import java.time.Duration
 typealias MemoizedRecord = HashMap<String, Any>
 typealias MemoizedState = HashMap<String, MemoizedRecord>
 
-data class InngestEvent(
-    val name: String,
-    val data: Any,
-)
-
-data class SendEventsResponse(
-    val ids: Array<String>,
-) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as SendEventsResponse
-
-        return ids.contentEquals(other.ids)
-    }
-
-    override fun hashCode(): Int = ids.contentHashCode()
-}
-
 class StepInvalidStateTypeException(
     val id: String,
     val hashedId: String,
@@ -51,7 +31,7 @@ class StepInterruptSleepException(
 class StepInterruptSendEventException(
     id: String,
     hashedId: String,
-    val eventIds: Array<String>,
+    val eventIds: List<String>,
 ) : StepInterruptException(id, hashedId, eventIds)
 
 class StepInterruptInvokeException(
@@ -200,15 +180,15 @@ class Step(
         val hashedId = state.getHashFromId(id)
 
         try {
-            val stepState = state.getState<Array<String>>(hashedId, "event_ids")
+            val stepState = state.getState<List<String>>(hashedId, "event_ids")
 
             if (stepState != null) {
-                return SendEventsResponse(stepState)
+                return SendEventsResponse(stepState, 200)
             }
             throw Exception("step state expected sendEvent, got something else")
         } catch (e: StateNotFound) {
-            val response = client.send<SendEventsResponse>(events)
-            throw StepInterruptSendEventException(id, hashedId, response!!.ids)
+            val response = client.send(events)
+            throw StepInterruptSendEventException(id, hashedId, response.ids)
         }
     }
 


### PR DESCRIPTION
## Summary

Fix and improve how events are sent using the `Inngest` client's `send` method. 

Changes:
* New exceptions to be thrown to handle specific types of Inngest Event API and event sending errors
* `InngestEventBuilder` to expose a builder pattern to creating events
* Refactor `Step.kt` to merge and simplify data classes


## Checklist
<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Added a [docs PR](https://github.com/inngest/website) that references this PR
- [ ] Added unit/integration tests

## Related
- INN-3336
