### PR TITLE
Fix FAIL_ON_EMPTY_BEANS error 

### DIFF
--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -3,6 +3,7 @@ package com.inngest
 import com.beust.klaxon.Json
 import com.beust.klaxon.Klaxon
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
 import com.inngest.signingkey.getAuthorizationHeader
 import java.io.IOException
 
@@ -111,6 +112,7 @@ class CommHandler(
 
     private fun parseRequestBody(requestBody: Any?): String {
         val mapper = ObjectMapper()
+        mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
         return mapper.writeValueAsString(requestBody)
     }
 

--- a/inngest/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest/src/main/kotlin/com/inngest/Function.kt
@@ -70,8 +70,9 @@ internal class InternalFunctionConfig
     @JvmOverloads
     constructor(
         val id: String,
+        @Json(serializeNull = false)
         val name: String?,
-        val triggers: MutableList<InngestFunctionTrigger>,
+        val triggers: MutableList<InngestFunctionTrigger> = mutableListOf(),
         @Json(serializeNull = false)
         val concurrency: MutableList<Concurrency>? = null,
         @Json(serializeNull = false)

--- a/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
+++ b/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
@@ -151,7 +151,7 @@ class InngestFunctionConfigBuilder {
         val config =
             InternalFunctionConfig(
                 globalId,
-                name,
+                name ?: id,
                 triggers,
                 concurrency,
                 batchEvents,

--- a/inngest/src/main/kotlin/com/inngest/Step.kt
+++ b/inngest/src/main/kotlin/com/inngest/Step.kt
@@ -124,7 +124,7 @@ class Step(
         appId: String,
         fnId: String,
         data: Any?,
-        timeout: String?,
+        timeout: String? = null,
     ): T = invoke(id, appId, fnId, data, timeout, T::class.java)
 
     fun <T> invoke(


### PR DESCRIPTION
## Summary

Prevent the payload parsing from failing on this error.

Additional changes:
* Set default for invoke timeout
* Use function `id` when `name` is not provided.

