### PR TITLE
Support try-catch for both `invoke` and `run`

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/InvokeFailureFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/InvokeFailureFunction.java
@@ -1,0 +1,36 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.*;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.LinkedHashMap;
+
+public class InvokeFailureFunction extends InngestFunction {
+
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("invoke-failure-fn")
+            .name("Invoke Function")
+            .triggerEvent("test/invoke.failure");
+    }
+
+    @Override
+    public String execute(FunctionContext ctx, Step step) {
+        try {
+            step.invoke(
+                "failing-function",
+                "spring_test_demo",
+                "non-retriable-fn",
+                new LinkedHashMap<String,
+                    String>(),
+                null,
+                Object.class);
+        } catch (StepError e) {
+            return e.getMessage();
+        }
+
+        return "An error should have been thrown and this message should not be returned";
+    }
+}

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/NonRetriableErrorFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/NonRetriableErrorFunction.java
@@ -17,7 +17,7 @@ public class NonRetriableErrorFunction extends InngestFunction {
     @Override
     public String execute(FunctionContext ctx, Step step) {
         step.run("fail-step", () -> {
-            throw new NonRetriableError("something fatally went wrong");
+            throw new NonRetriableError("Something fatally went wrong");
         }, String.class);
 
         return "Success";

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/TryCatchRunFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/TryCatchRunFunction.java
@@ -1,0 +1,36 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.*;
+import org.jetbrains.annotations.NotNull;
+
+class CustomException extends RuntimeException {
+    public CustomException(String message) {
+        super(message);
+    }
+}
+
+public class TryCatchRunFunction extends InngestFunction {
+
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("try-catch-run-fn")
+            .name("Try catch run")
+            .triggerEvent("test/try.catch.run")
+            .retries(0);
+    }
+
+    @Override
+    public String execute(FunctionContext ctx, Step step) {
+        try {
+            step.run("fail-step", () -> {
+                throw new CustomException("Something fatally went wrong");
+            }, String.class);
+        } catch (StepError e) {
+            return e.getMessage();
+        }
+
+        return "An error should have been thrown and this message should not be returned";
+    }
+}

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -21,6 +21,8 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, new NonRetriableErrorFunction());
         addInngestFunction(functions, new RetriableErrorFunction());
         addInngestFunction(functions, new ZeroRetriesFunction());
+        addInngestFunction(functions, new InvokeFailureFunction());
+        addInngestFunction(functions, new TryCatchRunFunction());
 
         return functions;
     }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/ErrorsInStepsIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/ErrorsInStepsIntegrationTest.java
@@ -35,7 +35,7 @@ class ErrorsInStepsIntegrationTest {
         assertNotNull(run.getEnded_at());
         assert output.get("name").contains("NonRetriableError");
         assert output.get("stack").contains("NonRetriableErrorFunction.lambda$execute");
-        assertEquals(output.get("message"), "something fatally went wrong");
+        assertEquals(output.get("message"), "Something fatally went wrong");
     }
 
     @Test

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/StepErrorsIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/StepErrorsIntegrationTest.java
@@ -1,0 +1,60 @@
+package com.inngest.springbootdemo;
+
+import com.inngest.CommHandler;
+import com.inngest.Inngest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
+class StepErrorsIntegrationTest {
+    @BeforeAll
+    static void setup(@Autowired CommHandler handler) {
+        handler.register("http://localhost:8080");
+    }
+
+    @Autowired
+    private DevServerComponent devServer;
+
+    static int sleepTime = 5000;
+
+    @Autowired
+    private Inngest client;
+
+    @Test
+    void testShouldCatchStepErrorWhenInvokeThrows() throws Exception {
+        String eventId = InngestFunctionTestHelpers.sendEvent(client, "test/invoke.failure").first();
+
+        Thread.sleep(sleepTime);
+
+        RunEntry<Object> run = devServer.runsByEvent(eventId).first();
+        String output = (String) run.getOutput();
+
+        assertEquals("Completed", run.getStatus() );
+        assertNotNull(run.getEnded_at());
+
+        assertEquals("Something fatally went wrong", output);
+    }
+
+    @Test
+    void testShouldCatchStepErrorWhenRunThrows() throws Exception {
+        String eventId = InngestFunctionTestHelpers.sendEvent(client, "test/try.catch.run").first();
+
+        Thread.sleep(sleepTime);
+
+        RunEntry<Object> run = devServer.runsByEvent(eventId).first();
+        String output = (String) run.getOutput();
+
+        assertEquals("Completed", run.getStatus());
+        assertNotNull(run.getEnded_at());
+
+        assertEquals("Something fatally went wrong", output);
+    }
+
+}

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/StepErrorsIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/StepErrorsIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.CommHandler;
 import com.inngest.Inngest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -14,11 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @IntegrationTest
 @Execution(ExecutionMode.CONCURRENT)
 class StepErrorsIntegrationTest {
-    @BeforeAll
-    static void setup(@Autowired CommHandler handler) {
-        handler.register("http://localhost:8080");
-    }
-
     @Autowired
     private DevServerComponent devServer;
 

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/App.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/App.kt
@@ -26,6 +26,8 @@ fun Application.module() {
                 RestoreFromGlacier(),
                 ProcessUserSignup(),
                 TranscodeVideo(),
+                ImageFromPrompt(),
+                PushToSlackChannel(),
             ),
         )
     }

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/ImageFromPrompt.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/ImageFromPrompt.kt
@@ -1,0 +1,47 @@
+package com.inngest.testserver
+
+import com.inngest.*
+
+class ImageFromPrompt : InngestFunction() {
+    override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder =
+        builder
+            .id("ImageFromPrompt")
+            .name("Image from Prompt")
+            .triggerEvent("media/prompt.created")
+
+    override fun execute(
+        ctx: FunctionContext,
+        step: Step,
+    ): String {
+        val imageURL =
+            try {
+                step.run("generate-image-dall-e") {
+                    // Call the DALL-E model to generate an image
+                    throw Exception("Failed to generate image")
+
+                    "example.com/image-dall-e.jpg"
+                }
+            } catch (e: StepError) {
+                // Fall back to a different image generation model
+                step.run("generate-image-midjourney") {
+                    // Call the MidJourney model to generate an image
+                    "example.com/image-midjourney.jpg"
+                }
+            }
+
+        try {
+            step.invoke<Map<String, Any>>(
+                "push-to-slack-channel",
+                "ktor-dev",
+                "PushToSlackChannel",
+                mapOf("image" to imageURL),
+                null,
+            )
+        } catch (e: StepError) {
+            // Pushing to Slack is not critical, so we can ignore the error, log it
+            // or handle it in some other way.
+        }
+
+        return imageURL
+    }
+}

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/PushToSlackChannel.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/PushToSlackChannel.kt
@@ -1,0 +1,22 @@
+package com.inngest.testserver
+
+import com.inngest.*
+
+class PushToSlackChannel : InngestFunction() {
+    override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder =
+        builder
+            .id("PushToSlackChannel")
+            .name("Push to Slack Channel")
+            .triggerEvent("media/image.generated")
+
+    override fun execute(
+        ctx: FunctionContext,
+        step: Step,
+    ): String =
+        step.run("push-to-slack-channel") {
+            // Call Slack API to push the image to a channel
+            throw NonRetriableError("Failed to push image to Slack channel ${ctx.event.data["image"]}")
+
+            "Image pushed to Slack channel"
+        }
+}

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -52,6 +52,8 @@ data class CommError(
     val __serialized: Boolean = true,
 )
 
+private val stepTerminalStatusCodes = setOf(ResultStatusCode.StepComplete, ResultStatusCode.StepError)
+
 class CommHandler(
     functions: Map<String, InngestFunction>,
     val client: Inngest,
@@ -81,13 +83,7 @@ class CommHandler(
 
             val result = function.call(ctx = ctx, client = client, requestBody)
             var body: Any? = null
-            if (result.statusCode in
-                setOf(
-                    ResultStatusCode.StepComplete,
-                    ResultStatusCode.StepError,
-                ) ||
-                result is StepOptions
-            ) {
+            if (result.statusCode in stepTerminalStatusCodes || result is StepOptions) {
                 body = listOf(result)
             }
             if (result is StepResult && result.statusCode == ResultStatusCode.FunctionComplete) {

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -81,7 +81,13 @@ class CommHandler(
 
             val result = function.call(ctx = ctx, client = client, requestBody)
             var body: Any? = null
-            if (result.statusCode == ResultStatusCode.StepComplete || result is StepOptions) {
+            if (result.statusCode in
+                setOf(
+                    ResultStatusCode.StepComplete,
+                    ResultStatusCode.StepError,
+                ) ||
+                result is StepOptions
+            ) {
                 body = listOf(result)
             }
             if (result is StepResult && result.statusCode == ResultStatusCode.FunctionComplete) {
@@ -94,7 +100,8 @@ class CommHandler(
             )
         } catch (e: Exception) {
             val retryDecision = RetryDecision.fromException(e)
-            val statusCode = if (retryDecision.shouldRetry) ResultStatusCode.RetriableError else ResultStatusCode.NonRetriableError
+            val statusCode =
+                if (retryDecision.shouldRetry) ResultStatusCode.RetriableError else ResultStatusCode.NonRetriableError
 
             val err =
                 CommError(

--- a/inngest/src/main/kotlin/com/inngest/State.kt
+++ b/inngest/src/main/kotlin/com/inngest/State.kt
@@ -38,8 +38,8 @@ class State(
             val dataNode = stepResult.get(fieldName)
             return mapper.treeToValue(dataNode, type)
         } else if (stepResult.has("error")) {
-            // TODO - Parse the error and throw it
-            return null
+            val error = mapper.treeToValue(stepResult.get("error"), StepError::class.java)
+            throw error
         }
         // NOTE - Sleep steps will be stored as null
         // TODO - Investigate if sendEvents stores null as well.

--- a/inngest/src/main/kotlin/com/inngest/StepError.kt
+++ b/inngest/src/main/kotlin/com/inngest/StepError.kt
@@ -1,0 +1,19 @@
+package com.inngest
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+/**
+ * Wraps user-space errors that occurred during the execution of a step.
+ *
+ * @param message The user-space error message
+ * @param name The name of the user-space error
+ * @param stack The original stack trace of the user-space error
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+class StepError
+    @JvmOverloads
+    constructor(
+        message: String,
+        val name: String = "",
+        val stack: String = "",
+    ) : RuntimeException(message)


### PR DESCRIPTION
## Summary
If an exception is thrown in the `invoke` or `run` function, it will now
be caught and returned as a `StepError` exception. This will allow the
error to be propagated to the caller and handled appropriately.

Transforming the errors into a `StepError` exception is following the
SDK spec:
https://github.com/inngest/inngest/blob/main/docs/SDK_SPEC.md#522-memoizing-a-step
JS SDK behavior:
https://github.com/inngest/inngest-js/blob/4f91d9c302592ecc2228914469dd057ae148005b/packages/inngest/src/components/execution/v1.ts#L437-L443
Docs:
https://www.inngest.com/docs/features/inngest-functions/error-retries/inngest-errors#step-errors

`StepError` is a `RuntimeException` which means that it can be used in Java code without needing to change the interface of `Inngest.execute` to introduce [checked exceptions](https://www.baeldung.com/kotlin/throws-annotation) or break existing `step.run` & `step.invoke` calls by requiring strict handling of the exception.

## Usage
### Invoke
```kotlin
try {
    step.invoke<Map<String, Any>>(
        "send-email",
        "ktor-dev",
        "Email",
        mapOf("email" to "example@example.com"),
        null,
    )
} catch (e: StepError) {
    // Handle error
}
```
### Run
```kotlin
try {
    step.run("send-email") {
        // Run the step
    }
} catch (e: StepError) {
    // Handle error
}
```

<!-- Succinctly describe your change, providing context, what you've changed, and why in a sentence or two. -->

Changes:
- Create a [`StepError`](https://www.inngest.com/docs/features/inngest-functions/error-retries/inngest-errors#step-errors) exception that users can catch to handler errors.
- Add try/catch support for `step.run`.
- Add try/catch support for `step.invoke`.
- Implement example Kotlin functions demonstrating the usage.
- Implement integration tests for them.

## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Update documentation
- [x] Added unit/integration tests

## Related

<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

- [INN-3330](https://linear.app/inngest/issue/INN-3330/support-or-confirm-support-for-trycatch-of-steps#comment-ba213027)
