### PR TITLE
Fix for randomly failing integration tests

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/DevServerComponent.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/DevServerComponent.java
@@ -3,6 +3,7 @@ package com.inngest.springbootdemo;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.inngest.CommHandler;
 import okhttp3.Request;
 
 import javax.annotation.PreDestroy;
@@ -14,24 +15,25 @@ public class DevServerComponent {
     static String baseUrl = "http://127.0.0.1:8288";
     OkHttpClient httpClient = new OkHttpClient();
 
-    DevServerComponent() throws Exception {
+    DevServerComponent(CommHandler commHandler) throws Exception {
         Runtime rt = Runtime.getRuntime();
         rt.exec("pkill inngest-cli");
         rt.exec("npx -y inngest-cli dev -u http://127.0.0.1:8080/api/inngest");
 
-        waitForStartup();
+        waitForStartup(commHandler);
     }
 
-    private void waitForStartup() throws Exception {
-
+    private void waitForStartup(CommHandler commHandler) throws Exception {
         while (true) {
             try {
                 Request request = new Request.Builder()
-                    .url(baseUrl)
+                    .url(String.format("%s/health", baseUrl))
                     .build();
 
                 try (Response response = httpClient.newCall(request).execute()) {
                     if (response.code() == 200) {
+                        Thread.sleep(3000);
+                        commHandler.register("http://localhost:8080");
                         return;
                     }
                 }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CustomStepResultIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CustomStepResultIntegrationTest.java
@@ -1,9 +1,7 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.CommHandler;
 import com.inngest.Inngest;
 import com.inngest.springbootdemo.testfunctions.TestFuncResult;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -14,11 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @IntegrationTest
 @Execution(ExecutionMode.CONCURRENT)
 class CustomStepResultIntegrationTest {
-    @BeforeAll
-    static void setup(@Autowired CommHandler handler) {
-        handler.register("http://localhost:8080");
-    }
-
     @Autowired
     private DevServerComponent devServer;
 

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -47,7 +47,7 @@ public class DemoTestConfiguration extends InngestConfiguration {
     }
 
     @Bean
-    protected DevServerComponent devServerComponent(@Autowired Inngest inngestClient) throws Exception {
-        return new DevServerComponent();
+    protected DevServerComponent devServerComponent(@Autowired CommHandler commHandler) throws Exception {
+        return new DevServerComponent(commHandler);
     }
 }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/ErrorsInStepsIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/ErrorsInStepsIntegrationTest.java
@@ -1,14 +1,11 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.CommHandler;
 import com.inngest.Inngest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,11 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @IntegrationTest
 @Execution(ExecutionMode.CONCURRENT)
 class ErrorsInStepsIntegrationTest {
-    @BeforeAll
-    static void setup(@Autowired CommHandler handler) {
-        handler.register("http://localhost:8080");
-    }
-
     @Autowired
     private DevServerComponent devServer;
 

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/MultiStepsFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/MultiStepsFunctionIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.CommHandler;
 import com.inngest.Inngest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -13,11 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @IntegrationTest
 @Execution(ExecutionMode.CONCURRENT)
 class MultiStepsFunctionIntegrationTest {
-    @BeforeAll
-    static void setup(@Autowired CommHandler handler) {
-        handler.register("http://localhost:8080");
-    }
-
     @Autowired
     private DevServerComponent devServer;
 

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/NoStepFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/NoStepFunctionIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.CommHandler;
 import com.inngest.Inngest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -13,11 +11,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @IntegrationTest
 @Execution(ExecutionMode.CONCURRENT)
 class NoStepFunctionIntegrationTest {
-    @BeforeAll
-    static void setup(@Autowired CommHandler handler) {
-        handler.register("http://localhost:8080");
-    }
-
     @Autowired
     private DevServerComponent devServer;
 

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/SendEventFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/SendEventFunctionIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.CommHandler;
 import com.inngest.Inngest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -16,11 +14,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @IntegrationTest
 @Execution(ExecutionMode.CONCURRENT)
 class SendEventFunctionIntegrationTest {
-    @BeforeAll
-    static void setup(@Autowired CommHandler handler) {
-        handler.register("http://localhost:8080");
-    }
-
     @Autowired
     private DevServerComponent devServer;
 

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/SleepFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/SleepFunctionIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.CommHandler;
 import com.inngest.Inngest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -13,12 +11,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @IntegrationTest
 @Execution(ExecutionMode.CONCURRENT)
 class SleepFunctionIntegrationTest {
-
-    @BeforeAll
-    static void setup(@Autowired CommHandler handler) {
-        handler.register("http://localhost:8080");
-    }
-
     @Autowired
     private DevServerComponent devServer;
 

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/WaitForEventFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/WaitForEventFunctionIntegrationTest.java
@@ -1,8 +1,6 @@
 package com.inngest.springbootdemo;
 
-import com.inngest.CommHandler;
 import com.inngest.Inngest;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -13,12 +11,6 @@ import static org.junit.jupiter.api.Assertions.*;
 @IntegrationTest
 @Execution(ExecutionMode.CONCURRENT)
 class WaitForEventFunctionIntegrationTest {
-
-    @BeforeAll
-    static void setup(@Autowired CommHandler handler) {
-        handler.register("http://localhost:8080");
-    }
-
     @Autowired
     private DevServerComponent devServer;
 


### PR DESCRIPTION
## Summary
This fixes randomly failing integration tests in CI.

Changes:

- Increase the wait time for the dev server to start up to 3 seconds.
- Use the health endpoint to check if the dev server is ready.
- Register the `CommHandler` only once after the dev server is ready instead of registering it before each test class.

