### PR TITLE
Forbid introspect endpoint in non-dev environments

### DIFF
--- a/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
+++ b/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
@@ -2,6 +2,7 @@ package com.inngest.springboot;
 
 import com.inngest.CommHandler;
 import com.inngest.CommResponse;
+import com.inngest.InngestEnv;
 import com.inngest.signingkey.SignatureVerificationKt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,6 +32,11 @@ public abstract class InngestController {
         @RequestHeader(HttpHeaders.HOST) String hostHeader,
         HttpServletRequest request
     ) {
+        if (commHandler.getClient().getEnv() != InngestEnv.Dev) {
+            // TODO: Return an UnauthenticatedIntrospection instead when app diagnostics are implemented
+            return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body("Introspect endpoint is only available in development mode");
+        }
         String origin = String.format("%s://%s", request.getScheme(), hostHeader);
         if (this.serveOrigin != null && !this.serveOrigin.isEmpty()) {
             origin = this.serveOrigin;

--- a/inngest/src/main/kotlin/com/inngest/ktor/Route.kt
+++ b/inngest/src/main/kotlin/com/inngest/ktor/Route.kt
@@ -43,6 +43,12 @@ fun Route.serve(
 
     route(path) {
         get("") {
+            if (client.env != InngestEnv.Dev) {
+                // TODO: Return an UnauthenticatedIntrospection instead when app diagnostics are implemented
+                call.respond(HttpStatusCode.Forbidden, "Introspect endpoint is only available in development mode")
+                return@get
+            }
+
             val origin = getOrigin(call)
             val resp = comm.introspect(origin)
             call.respond(HttpStatusCode.OK, resp)


### PR DESCRIPTION
## Summary
Return a forbidden response when calling the `introspect` endpoint from non-dev environments. This will be short-lived and replaced with the app diagnostics feature soon.

## Related

<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

- [INN-3474](https://linear.app/inngest/issue/INN-3474/disable-introspect-endpoint-if-inngest-dev-not-true)
