### PR TITLE
Implement debounce configuration

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/DebouncedFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/DebouncedFunction.java
@@ -1,0 +1,30 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.FunctionContext;
+import com.inngest.InngestFunction;
+import com.inngest.InngestFunctionConfigBuilder;
+import com.inngest.Step;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+
+public class DebouncedFunction extends InngestFunction {
+
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("DebouncedFunction")
+            .name("Debounced Function")
+            .triggerEvent("test/debounced_2_second")
+            .debounce(Duration.ofSeconds(2));
+    }
+
+    private static int answer = 42;
+
+    @Override
+    public Integer execute(FunctionContext ctx, Step step) {
+        return step.run("result", () -> answer++, Integer.class);
+    }
+}
+

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DebouncedFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DebouncedFunctionIntegrationTest.java
@@ -1,0 +1,35 @@
+package com.inngest.springbootdemo;
+
+import com.inngest.Inngest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
+class DebouncedFunctionIntegrationTest {
+    @Autowired
+    private DevServerComponent devServer;
+
+    @Autowired
+    private Inngest client;
+
+    @Test
+    void testDebouncedFunctionExecutesTrailingEdge() throws Exception {
+        String firstEvent = InngestFunctionTestHelpers.sendEvent(client, "test/debounced_2_second").getIds()[0];
+        String secondEvent = InngestFunctionTestHelpers.sendEvent(client, "test/debounced_2_second").getIds()[0];
+
+        Thread.sleep(4000);
+
+        // With debouncing, the first event is skipped in favor of the second one because they were both sent within
+        // the debounce period of 2 seconds
+        assertEquals(0, devServer.runsByEvent(firstEvent).data.length);
+        RunEntry<Object> secondRun = devServer.runsByEvent(secondEvent).first();
+
+        assertEquals("Completed", secondRun.getStatus());
+        assertEquals(42, secondRun.getOutput());
+    }
+}

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -24,6 +24,7 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, new InvokeFailureFunction());
         addInngestFunction(functions, new TryCatchRunFunction());
         addInngestFunction(functions, new ThrottledFunction());
+        addInngestFunction(functions, new DebouncedFunction());
 
         return functions;
     }

--- a/inngest/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest/src/main/kotlin/com/inngest/Function.kt
@@ -81,6 +81,8 @@ internal class InternalFunctionConfig
         @Json(serializeNull = false)
         val throttle: Throttle? = null,
         @Json(serializeNull = false)
+        val debounce: Debounce? = null,
+        @Json(serializeNull = false)
         val batchEvents: BatchEvents? = null,
         val steps: Map<String, StepConfig>,
     )


### PR DESCRIPTION

## Summary

Add `debounce` configuration, Follows similar pattern to recently added `throttle`

The integration test timing could lead to flakes but I tried to leave
a generous buffer to minimize this without making the test too long.

I wanted to add a second integration test for the debounce `timeout`,
but configuring debounce with a `timeout` seems to result in the
function never getting executed on the latest dev server (0.29.6). I
verified this is true with the JS SDK as well.

Documentation for debounce mostly copied from JS SDK

## Checklist

- [x] Update documentation
- [x] Added unit/integration tests

## Related

- INN-3333
