### PR TITLE
Add priority configuration

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/PriorityFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/PriorityFunction.java
@@ -1,0 +1,31 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.FunctionContext;
+import com.inngest.InngestFunction;
+import com.inngest.InngestFunctionConfigBuilder;
+import com.inngest.Step;
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+
+// This function is not currently being exercised by any integration test,
+// but including it here and in DemoTestConfiguration means we are at least testing
+// that it can be registered with the inngest dev server properly
+public class PriorityFunction extends InngestFunction {
+
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("PriorityFunction")
+            .name("Priority Function")
+            .triggerEvent("test/priority")
+            .priority("100");
+    }
+
+    @Override
+    public Integer execute(FunctionContext ctx, Step step) {
+        return step.run("result", () -> 42, Integer.class);
+    }
+}
+

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -25,6 +25,7 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, new TryCatchRunFunction());
         addInngestFunction(functions, new ThrottledFunction());
         addInngestFunction(functions, new DebouncedFunction());
+        addInngestFunction(functions, new PriorityFunction());
 
         return functions;
     }

--- a/inngest/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest/src/main/kotlin/com/inngest/Function.kt
@@ -82,6 +82,7 @@ internal class InternalFunctionConfig
         val throttle: Throttle? = null,
         @Json(serializeNull = false)
         val debounce: Debounce? = null,
+        val priority: Priority? = null,
         @Json(serializeNull = false)
         val batchEvents: BatchEvents? = null,
         val steps: Map<String, StepConfig>,

--- a/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
+++ b/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
@@ -15,6 +15,7 @@ class InngestFunctionConfigBuilder {
     private var retries = 3
     private var throttle: Throttle? = null
     private var debounce: Debounce? = null
+    private var priority: Priority? = null
     private var batchEvents: BatchEvents? = null
 
     /**
@@ -172,6 +173,19 @@ class InngestFunctionConfigBuilder {
         timeout: Duration? = null,
     ): InngestFunctionConfigBuilder = apply { this.debounce = Debounce(period, key, timeout) }
 
+    /**
+     *
+     * Configure how the priority of a function run is decided when multiple
+     * functions are triggered at the same time.
+     *
+     * @param run An expression to use to determine the priority of a function run. The
+     * expression can return a number between `-600` and `600`, where `600`
+     * declares that this run should be executed before any others enqueued in
+     * the last 600 seconds (10 minutes), and `-600` declares that this run
+     * should be executed after any others enqueued in the last 600 seconds.
+     */
+    fun priority(run: String): InngestFunctionConfigBuilder = apply { this.priority = Priority(run) }
+
     private fun buildSteps(serveUrl: String): Map<String, StepConfig> {
         val scheme = serveUrl.split("://")[0]
         return mapOf(
@@ -205,6 +219,7 @@ class InngestFunctionConfigBuilder {
                 concurrency,
                 throttle,
                 debounce,
+                priority,
                 batchEvents,
                 steps = buildSteps(serverUrl),
             )
@@ -284,6 +299,11 @@ internal data class Debounce
         @Json(serializeNull = false)
         @KlaxonDuration
         val timeout: Duration? = null,
+    )
+
+internal data class Priority
+    constructor(
+        val run: String,
     )
 
 internal data class BatchEvents


### PR DESCRIPTION
## Summary

`run` is marked as optional in the SDK spec and in the JS SDK, but this
means we could call with an empty `priority` which seems a bit weird, so
I made it required here.

This seems difficult to write a reliable integration test and it looks
like it was skipped in the other SDKs as well
- https://github.com/inngest/inngest-py/pull/114
- https://github.com/inngest/inngest-js/pull/362

One possible test scenario we can try in a follow up, in combination
with throttling
- 2 functions, fun_2 is higher priority than fun_1, they are throttled on the same key
- call fun_1, fun_1, fun_2 in that order
- check after the first execution of fun_1, that fun_2 got executed next
  before the second execution of fun_2

## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Update documentation
- [ ] Added unit/integration tests

## Related

<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

- INN-3334
