### PR TITLE
Fix hashing step ids in loops

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/LoopFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/LoopFunction.java
@@ -22,13 +22,22 @@ public class LoopFunction extends InngestFunction {
     public Integer execute(FunctionContext ctx, Step step) {
         int runningCount = 10;
 
+        // explicitly naming a step that the SDK will try to use in the loop shouldn't break the loop
         int effectivelyFinalVariableForLambda1 = runningCount;
         runningCount = step.run("add-num:3", () -> effectivelyFinalVariableForLambda1 + 50, Integer.class);
 
         for (int i = 0; i < 5; i++) {
             int effectivelyFinalVariableForLambda2 = runningCount;
+            // The actual stepIds used will be add-num, add-num:1, add-num:2, add-num:4, add-num:5
             runningCount = step.run("add-num", () -> effectivelyFinalVariableForLambda2 + 10, Integer.class);
         }
+
+        // explicitly reusing step names that the SDK used during the loop should both execute
+        // These will be modified to add-num:4:1 and add-num:4:2 respectively
+        int effectivelyFinalVariableForLambda3 = runningCount;
+        runningCount = step.run("add-num:4", () -> effectivelyFinalVariableForLambda3 + 30, Integer.class);
+        int effectivelyFinalVariableForLambda4 = runningCount;
+        runningCount = step.run("add-num:4", () -> effectivelyFinalVariableForLambda4 + 30, Integer.class);
 
         return runningCount;
     }

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/LoopFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/LoopFunction.java
@@ -21,9 +21,13 @@ public class LoopFunction extends InngestFunction {
     @Override
     public Integer execute(FunctionContext ctx, Step step) {
         int runningCount = 10;
+
+        int effectivelyFinalVariableForLambda1 = runningCount;
+        runningCount = step.run("add-num:3", () -> effectivelyFinalVariableForLambda1 + 50, Integer.class);
+
         for (int i = 0; i < 5; i++) {
-            int effectivelyFinalVariableForLambda = runningCount;
-            runningCount = step.run("add-ten", () -> effectivelyFinalVariableForLambda + 10, Integer.class);
+            int effectivelyFinalVariableForLambda2 = runningCount;
+            runningCount = step.run("add-num", () -> effectivelyFinalVariableForLambda2 + 10, Integer.class);
         }
 
         return runningCount;

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/LoopFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/LoopFunction.java
@@ -1,0 +1,32 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.FunctionContext;
+import com.inngest.InngestFunction;
+import com.inngest.InngestFunctionConfigBuilder;
+import com.inngest.Step;
+import org.jetbrains.annotations.NotNull;
+
+public class LoopFunction extends InngestFunction {
+
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("loop-fn")
+            .name("Loop Function")
+            .triggerEvent("test/loop");
+    }
+
+
+    @Override
+    public Integer execute(FunctionContext ctx, Step step) {
+        int runningCount = 10;
+        for (int i = 0; i < 5; i++) {
+            int effectivelyFinalVariableForLambda = runningCount;
+            runningCount = step.run("add-ten", () -> effectivelyFinalVariableForLambda + 10, Integer.class);
+        }
+
+        return runningCount;
+    }
+}
+

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -30,6 +30,7 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, new Scale2DObjectFunction());
         addInngestFunction(functions, new MultiplyMatrixFunction());
         addInngestFunction(functions, new WithOnFailureFunction());
+        addInngestFunction(functions, new LoopFunction());
 
         return functions;
     }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/LoopFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/LoopFunctionIntegrationTest.java
@@ -25,6 +25,6 @@ class LoopFunctionIntegrationTest {
         RunEntry<Object> loopRun = devServer.runsByEvent(loopEvent).first();
         assertEquals("Completed", loopRun.getStatus());
 
-        assertEquals(60, loopRun.getOutput());
+        assertEquals(110, loopRun.getOutput());
     }
 }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/LoopFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/LoopFunctionIntegrationTest.java
@@ -1,0 +1,30 @@
+package com.inngest.springbootdemo;
+
+import com.inngest.Inngest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
+class LoopFunctionIntegrationTest {
+    @Autowired
+    private DevServerComponent devServer;
+
+    @Autowired
+    private Inngest client;
+
+    @Test
+    void testStepsInLoopExecuteCorrectly() throws Exception {
+        String loopEvent = InngestFunctionTestHelpers.sendEvent(client, "test/loop").getIds()[0];
+        Thread.sleep(2000);
+
+        RunEntry<Object> loopRun = devServer.runsByEvent(loopEvent).first();
+        assertEquals("Completed", loopRun.getStatus());
+
+        assertEquals(60, loopRun.getOutput());
+    }
+}

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/LoopFunctionIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/LoopFunctionIntegrationTest.java
@@ -25,6 +25,6 @@ class LoopFunctionIntegrationTest {
         RunEntry<Object> loopRun = devServer.runsByEvent(loopEvent).first();
         assertEquals("Completed", loopRun.getStatus());
 
-        assertEquals(110, loopRun.getOutput());
+        assertEquals(170, loopRun.getOutput());
     }
 }

--- a/inngest/src/main/kotlin/com/inngest/State.kt
+++ b/inngest/src/main/kotlin/com/inngest/State.kt
@@ -27,21 +27,20 @@ class State(
     }
 
     private fun findNextAvailableStepId(id: String): String {
-        if (id !in stepIdsToNextStepNumber) {
-            stepIdsToNextStepNumber[id] = 1
+        if (id !in stepIds) {
             return id
         }
 
         // start with the seen count so far for current stepId
         // but loop over all seen stepIds to make sure a user didn't explicitly define
         // a step using the same step number
-        var stepNumber = stepIdsToNextStepNumber[id]
+        var stepNumber = stepIdsToNextStepNumber.getOrDefault(id, 1)
         while ("$id:$stepNumber" in stepIds) {
-            stepNumber = stepNumber!! + 1
+            stepNumber = stepNumber + 1
         }
         // now we know stepNumber is unused and can be used for the current stepId
         // save stepNumber + 1 to the hash for next time
-        stepIdsToNextStepNumber[id] = stepNumber!! + 1
+        stepIdsToNextStepNumber[id] = stepNumber + 1
 
         return "$id:$stepNumber"
     }


### PR DESCRIPTION
## Summary

Per https://github.com/inngest/inngest/blob/main/docs/SDK_SPEC.md#512-ids-and-hashing,
add `:n` starting with `:1` for repeated instances of a step id

Refactored to be a combination of golang and inngest-js implementation to handle edge case of user defined stepId colliding
- https://github.com/inngest/inngestgo/blob/0a00daba0b2db68ff0f080f787cf63f0a63b44d8/internal/sdkrequest/manager.go#L123-L131
- https://github.com/inngest/inngest-js/blob/79069e1a3d700624ce49b323922c113fc952bcc6/packages/inngest/src/components/execution/v1.ts#L819-L831

The inngest-js SDK currently optionally warns of parallel indexing, but
this isn't in scope for beta so I left it out.


## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Update documentation~~ N/A documented by sdk spec
- [x] Added unit/integration tests

## Related

<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

- INN-3329
