### PR TITLE
Fix response headers not being set by `ktor`

### DIFF
--- a/inngest/src/main/kotlin/com/inngest/ktor/Route.kt
+++ b/inngest/src/main/kotlin/com/inngest/ktor/Route.kt
@@ -62,21 +62,15 @@ fun Route.serve(
                 val body = call.receiveText()
                 try {
                     val response = comm.callFunction(fnId, body)
-                    call.response.header(
-                        HttpHeaders.ContentType,
-                        ContentType.Application.Json.toString(),
-                    )
+                    response.headers.forEach({ (k, v) -> call.response.header(k, v) })
                     call.response.status(
                         HttpStatusCode(response.statusCode.code, response.statusCode.message),
                     )
-//                    println("response: " + response.body)
-                    call.respond(response.body)
+                    call.respondText(response.body)
                 } catch (e: Exception) {
                     call.respond(HttpStatusCode.InternalServerError, e.toString())
                 }
             }
-
-            call.respondText("Invoke functions")
         }
 
         put("") {


### PR DESCRIPTION
## Summary

Most of the response headers weren't being set correctly in the ktor adapter which means that `NonRetriableError` which works by setting the `x-inngest-no-retry` header wasn't working correctly.

I don't think we have a way to test this since integration tests only cover the spring boot version for now.

###### Payload before
```
HTTP/1.1 206 Step Error
Content-Type: application/json
Content-Length: 17025
Content-Type: application/json
Connection: close

[{"id":"310c4f3bb1c6326c6b5064dfe071b224d6516f7c","name":"generate-image-dall-e","op":"StepError",...
```

###### Payload after
```
HTTP/1.1 206 Step Error
content-type: application/json
x-inngest-sdk: inngest-kt:version-not-found
user-agent: inngest-kt:version-not-found
x-inngest-framework: ktor
Content-Length: 17025
Content-Type: application/json
Connection: close

[{"id":"310c4f3bb1c6326c6b5064dfe071b224d6516f7c","name":"generate-image-dall-e","op":"StepError",...
```



## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Update documentation
- [ ] Added unit/integration tests

