### PR TITLE
Add SDK version in format `java:v{version}` to the sync call

### DIFF
--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoControllerTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoControllerTest.java
@@ -1,6 +1,7 @@
 package com.inngest.springbootdemo;
 
 import com.inngest.InngestHeaderKey;
+import com.inngest.Version;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -24,7 +25,9 @@ public class DemoControllerTest {
             .andExpect(content().contentType("application/json"))
             .andExpect(header().string(InngestHeaderKey.Framework.getValue(), "springboot"))
             .andExpect(jsonPath("$.appName").value("spring_test_demo"))
+            .andExpect(jsonPath("$.framework").value("springboot"))
+            .andExpect(jsonPath("$.v").value("0.1"))
             .andExpect(jsonPath("$.url").value("http://localhost:8080/api/inngest"))
-            .andExpect(jsonPath("$.sdk").value("inngest-kt"));
+            .andExpect(jsonPath("$.sdk").value(String.format("java:v%s", Version.Companion.getVersion())));
     }
 }

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -174,10 +174,10 @@ class CommHandler(
     private fun getRegistrationRequestPayload(origin: String): RegistrationRequestPayload =
         RegistrationRequestPayload(
             appName = config.appId(),
-            framework = framework.toString(),
-            sdk = "inngest-kt",
+            framework = framework.value,
+            sdk = "java:v${Version.getVersion()}",
             url = getServeUrl(origin),
-            v = Version.getVersion(),
+            v = "0.1",
             functions = getFunctionConfigs(origin),
         )
 


### PR DESCRIPTION
## Summary

Add the SDK version to the sync request payload, assuming that we are going with `java`  as the common denominator language : https://github.com/inngest/inngest-kt/pull/76#discussion_r1749007345

Confirming that now the language shows up as Java and the version shows up correctly in cloud mode:
![image](https://github.com/user-attachments/assets/7c34a665-2e08-4d5c-a30d-4c005d1d2c17)


Changes:
- Add the SDK version and correct language.
- Downcase the framework field.
- Set the const field `v` to `0.1` as mentioned in [the spec](https://github.com/inngest/inngest/blob/main/docs/SDK_SPEC.md#432-syncing).

## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Update documentation
- [x] Added unit/integration tests

## Related

<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

- [INN-3572](https://linear.app/inngest/issue/INN-3572/add-sdk-version-returned-in-introspection-payload)
