### PR TITLE
Add cancelOn configuration

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/CancelOnEventFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/CancelOnEventFunction.java
@@ -1,0 +1,30 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.FunctionContext;
+import com.inngest.InngestFunction;
+import com.inngest.InngestFunctionConfigBuilder;
+import com.inngest.Step;
+import org.jetbrains.annotations.NotNull;
+
+public class CancelOnEventFunction extends InngestFunction {
+
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("cancelable-fn")
+            .name("Cancelable Function")
+            .cancelOn("cancel/cancelable")
+            .triggerEvent("test/cancelable");
+    }
+
+    @Override
+    public String execute(FunctionContext ctx, Step step) {
+        step.waitForEvent("wait-forever",
+            "test/waiting-for-godot",
+            "10m",
+            null);
+
+        return "I didn't get canceled";
+    }
+}

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/CancelOnMatchFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/CancelOnMatchFunction.java
@@ -1,0 +1,31 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.FunctionContext;
+import com.inngest.InngestFunction;
+import com.inngest.InngestFunctionConfigBuilder;
+import com.inngest.Step;
+import org.jetbrains.annotations.NotNull;
+
+
+public class CancelOnMatchFunction extends InngestFunction {
+
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("cancel-on-match-fn")
+            .name("Cancel On Match Function")
+            .cancelOn("cancel/cancel-on-match", "event.data.userId == async.data.userId")
+            .triggerEvent("test/cancel-on-match");
+    }
+
+    @Override
+    public String execute(FunctionContext ctx, Step step) {
+        step.waitForEvent("wait-forever",
+            "test/waiting-for-godot",
+            "10m",
+            null);
+
+        return "I didn't get canceled";
+    }
+}

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CancellationIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CancellationIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.inngest.springbootdemo;
+
+import com.inngest.Inngest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
+class CancellationIntegrationTest {
+    @Autowired
+    private DevServerComponent devServer;
+
+    @Autowired
+    private Inngest client;
+
+    @Test
+    void testCancelOnEventOnly() throws Exception {
+        String event = InngestFunctionTestHelpers.sendEvent(client, "test/cancelable").getIds()[0];
+        Thread.sleep(1000);
+        InngestFunctionTestHelpers.sendEvent(client, "cancel/cancelable");
+        Thread.sleep(1000);
+
+        RunEntry<Object> run = devServer.runsByEvent(event).first();
+
+        assertEquals("Cancelled", run.getStatus());
+    }
+
+    @Test
+    void testCancelOnIf() throws Exception {
+        String user23Event = InngestFunctionTestHelpers.sendEvent(client, "test/cancel-on-match", Collections.singletonMap("userId", "23")).getIds()[0];
+        String user42Event = InngestFunctionTestHelpers.sendEvent(client, "test/cancel-on-match", Collections.singletonMap("userId", "42")).getIds()[0];
+        Thread.sleep(1000);
+        InngestFunctionTestHelpers.sendEvent(client, "cancel/cancel-on-match", Collections.singletonMap("userId", "42"));
+        Thread.sleep(1000);
+
+        // Only the event matching the if expression is canceled
+        assertEquals("Running", devServer.runsByEvent(user23Event).first().getStatus());
+        assertEquals("Cancelled", devServer.runsByEvent(user42Event).first().getStatus());
+    }
+}

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -32,6 +32,8 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, new MultiplyMatrixFunction());
         addInngestFunction(functions, new WithOnFailureFunction());
         addInngestFunction(functions, new LoopFunction());
+        addInngestFunction(functions, new CancelOnEventFunction());
+        addInngestFunction(functions, new CancelOnMatchFunction());
 
         return functions;
     }

--- a/inngest/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest/src/main/kotlin/com/inngest/Function.kt
@@ -89,6 +89,8 @@ internal class InternalFunctionConfig
         @Json(serializeNull = false)
         val idempotency: String? = null,
         @Json(serializeNull = false)
+        val cancel: MutableList<Cancellation>? = null,
+        @Json(serializeNull = false)
         val batchEvents: BatchEvents? = null,
         val steps: Map<String, StepConfig>,
     )

--- a/inngest/src/main/kotlin/com/inngest/InngestFunctionTriggers.kt
+++ b/inngest/src/main/kotlin/com/inngest/InngestFunctionTriggers.kt
@@ -11,7 +11,6 @@ abstract class InngestFunctionTrigger // or interface or data class
         @Json(serializeNull = false) val event: String? = null,
         @Json(serializeNull = false, name = "expression") val `if`: String? = null,
         @Json(serializeNull = false) val cron: String? = null,
-        // IDEA - Add timeout and re-use for cancelOn?
     )
 
 /**

--- a/inngest/src/test/kotlin/com/inngest/InngestFunctionConfigBuilderTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/InngestFunctionConfigBuilderTest.kt
@@ -1,5 +1,7 @@
 package com.inngest
 
+import java.time.Duration
+import java.time.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -84,5 +86,24 @@ class InngestFunctionConfigBuilderTest {
                 .concurrency(9, "event.data.account_id", ConcurrencyScope.ACCOUNT)
                 .build("app-id", "https://mysite.com/api/inngest")
         }
+    }
+
+    @Test
+    fun testCancelOnTimeout() {
+        val durationConfig =
+            InngestFunctionConfigBuilder()
+                .id("test-id")
+                .cancelOn("cancel", null, Duration.ofSeconds(6000))
+                .build("app-id", "https://mysite.com/api/inngest")
+
+        assertEquals<List<Cancellation>?>(listOf(Cancellation("cancel", null, "\"6000s\"")), durationConfig.cancel)
+
+        val instantConfig =
+            InngestFunctionConfigBuilder()
+                .id("test-id")
+                .cancelOn("cancel", null, Instant.ofEpochSecond(1726056053))
+                .build("app-id", "https://mysite.com/api/inngest")
+
+        assertEquals<List<Cancellation>?>(listOf(Cancellation("cancel", null, "2024-09-11T12:00:53Z")), instantConfig.cancel)
     }
 }


### PR DESCRIPTION
## Summary

- followed similar pattern to `InngestFunctionTriggers` but didn't reuse
  that class for a few reasons
  - `if` concept is similar but for triggers it gets serialized as `expression` but is `if` for cancel
  - `timeout` is only used by cancel and not for triggers and vice versa with `cron`, so it seems the `InngestFunctionTrigger` class's fields would be sparsely populated for all the concrete cases and not provide too much value in sharing code
  - While I like the idea of calling the "thing" that sets off Cancel as "CancelTrigger" or "CancellationTrigger", I thought this could be confusing since [triggers are their own key under configuration](https://github.com/inngest/inngest/blame/0ac11f2c312c066e517e53749052dd89fd2926ba/docs/SDK_SPEC.md#L478) 
- `Cancellation` name avoided "trigger" for reason above and followed pattern in https://github.com/inngest/inngest-js/blob/0e51903d5968a7287dd7e518bd5cc8acec3e6f3e/packages/inngest/src/types.ts#L901
- I originally was going to implement with `match` as well per https://www.inngest.com/docs/reference/typescript/functions/cancel-on, but I saw later that [it's currently deprecated so I stuck to `if` only](https://github.com/inngest/inngest-js/blob/0e51903d5968a7287dd7e518bd5cc8acec3e6f3e/packages/inngest/src/types.ts#L946). 
- Per the flexibility of timeout in https://github.com/inngest/inngest/blob/0ac11f2c312c066e517e53749052dd89fd2926ba/docs/SDK_SPEC.md?plain=1#L580-L583 The type for timeout is either `Duration` or `Instant`.


## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [x] Update documentation
- [x] Added unit/integration tests

## Related

<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

- INN-3335
