### PR TITLE
Upgrade actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         java: ["8", "11", "17", "21"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -30,7 +30,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: ktlint
         uses: ScaCap/action-ktlint@master
         with:
@@ -49,7 +49,7 @@ jobs:
       matrix:
         java: ["8", "11", "17", "21"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: temurin


### PR DESCRIPTION
## Summary

This resolves a warning about node version

## Checklist

- N/A github action change only
- [ ] ~~Update documentation~~
- [ ] ~~Added unit/integration tests~~ 

