### PR TITLE
Change range to be inclusive on upper bound 0.1

### DIFF
--- a/inngest-spring-boot-adapter/build.gradle.kts
+++ b/inngest-spring-boot-adapter/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    val pkg = if (System.getenv("RELEASE") != null) "com.inngest:inngest:[0.0.5, 0.1)" else project(":inngest")
+    val pkg = if (System.getenv("RELEASE") != null) "com.inngest:inngest:[0.0.5, 0.1]" else project(":inngest")
     api(pkg)
 
     implementation("org.springframework.boot:spring-boot-starter-web")


### PR DESCRIPTION
## Summary

Bump peer range to include 0.1

This is in preparation to cut 0.1.0 for inngest-spring-boot-adapter

## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Update documentation~~ N/A version bump only
- [ ] ~~Added unit/integration tests~~ N/A version bump only
