### PR TITLE
Fix serialization of subclasses

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/DeserializeSubclassFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/DeserializeSubclassFunction.java
@@ -1,0 +1,49 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.inngest.FunctionContext;
+import com.inngest.InngestFunction;
+import com.inngest.InngestFunctionConfigBuilder;
+import com.inngest.Step;
+import org.jetbrains.annotations.NotNull;
+
+class Dog {
+    @JsonProperty("legs")
+    public int legs;
+
+    public Dog(@JsonProperty("legs") int legs) {
+        this.legs = legs;
+    }
+}
+
+class Corgi extends Dog {
+    @JsonProperty("stumpy")
+    public boolean stumpy;
+
+    public Corgi(@JsonProperty("legs") int legs, @JsonProperty("stumpy") boolean stumpy) {
+        super(legs);
+
+        this.stumpy = stumpy;
+    }
+}
+
+public class DeserializeSubclassFunction extends InngestFunction {
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("DeserializeSubclassFunction")
+            .name("Deserialize subclass function")
+            .triggerEvent("test/deserialize.subclass")
+            .retries(0);
+    }
+
+    @Override
+    public String execute(FunctionContext ctx, Step step) {
+        Dog corgi = step.run("get-corgi", () -> new Corgi(4, true), Dog.class);
+
+        assert(((Corgi) corgi).stumpy == true);
+
+        return "Successfully cast Corgi";
+    }
+}

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/TryCatchGenericExceptionFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/TryCatchGenericExceptionFunction.java
@@ -1,0 +1,30 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.*;
+import org.jetbrains.annotations.NotNull;
+
+public class TryCatchGenericExceptionFunction extends InngestFunction {
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("try-catch-deserialize-exception-function")
+            .name("Try Catch Deserialize Exception Function")
+            .triggerEvent("test/try.catch.deserialize.exception")
+            .retries(0);
+    }
+
+    @Override
+    public String execute(FunctionContext ctx, Step step) {
+        try {
+            step.run("fail-step", () -> {
+                throw new CustomException("Something fatally went wrong");
+            }, String.class);
+        } catch (Exception originalException) {
+            Exception e = step.run("handle-error", () -> originalException, Exception.class);
+            return e.getMessage();
+        }
+
+        return "An error should have been thrown and this message should not be returned";
+    }
+}

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -22,6 +22,7 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, new RetriableErrorFunction());
         addInngestFunction(functions, new ZeroRetriesFunction());
         addInngestFunction(functions, new InvokeFailureFunction());
+        addInngestFunction(functions, new TryCatchGenericExceptionFunction());
         addInngestFunction(functions, new TryCatchRunFunction());
         addInngestFunction(functions, new ThrottledFunction());
         addInngestFunction(functions, new RateLimitedFunction());

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -22,6 +22,7 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, new RetriableErrorFunction());
         addInngestFunction(functions, new ZeroRetriesFunction());
         addInngestFunction(functions, new InvokeFailureFunction());
+        addInngestFunction(functions, new DeserializeSubclassFunction());
         addInngestFunction(functions, new TryCatchGenericExceptionFunction());
         addInngestFunction(functions, new TryCatchRunFunction());
         addInngestFunction(functions, new ThrottledFunction());

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DeserializationIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DeserializationIntegrationTest.java
@@ -1,0 +1,42 @@
+package com.inngest.springbootdemo;
+
+import com.inngest.Inngest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.LinkedHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
+class DeserializationIntegrationTest {
+    @Autowired
+    private DevServerComponent devServer;
+
+    static int sleepTime = 5000;
+
+    @Autowired
+    private Inngest client;
+
+    @Test
+    void testShouldDeserializeSubclassCorrectly() throws Exception {
+        String eventId = InngestFunctionTestHelpers.sendEvent(client, "test/deserialize.subclass").getIds()[0];
+
+        Thread.sleep(sleepTime);
+
+        RunEntry<Object> run = devServer.runsByEvent(eventId).first();
+        Object output = run.getOutput();
+        if (output instanceof LinkedHashMap) {
+            fail("Run threw an exception serialized into a LinkedHashMap:" + output);
+        }
+        String outputString = (String) output;
+
+        assertEquals("Completed", run.getStatus() );
+        assertNotNull(run.getEnded_at());
+
+        assertEquals("Successfully cast Corgi", outputString);
+    }
+}


### PR DESCRIPTION
## Summary

<!-- Succinctly describe your change, providing context, what you've changed, and why in a sentence or two. -->

Changes:

* Add integration test reproducing the issue when catching a `StepError` as a generic `Exception` 
* Add integration test showing that any subclass/parent class that gets memoized with the Inngest server will have this issue
* Resolve serialization issue by sending the class name in the step data payload and using it reflectively when deserializing

## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] ~~Update documentation~~
- [x] Added unit/integration tests

## Related

<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

https://inngest.slack.com/archives/C06KB85RXRV/p1728067438991139
