### PR TITLE
Fix random test failures caused by dev server timeouts

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/DevServerComponent.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/DevServerComponent.java
@@ -15,10 +15,11 @@ public class DevServerComponent {
     static String baseUrl = "http://127.0.0.1:8288";
     OkHttpClient httpClient = new OkHttpClient();
 
+    Process devServerProcess;
+
     DevServerComponent(CommHandler commHandler) throws Exception {
         Runtime rt = Runtime.getRuntime();
-        rt.exec("pkill inngest-cli");
-        rt.exec("npx -y inngest-cli dev -u http://127.0.0.1:8080/api/inngest");
+        devServerProcess = rt.exec("npx -y inngest-cli@latest dev -u http://localhost:8080/api/inngest --port 8288 --no-discovery --no-poll --retry-interval 1");
 
         waitForStartup(commHandler);
     }
@@ -32,7 +33,7 @@ public class DevServerComponent {
 
                 try (Response response = httpClient.newCall(request).execute()) {
                     if (response.code() == 200) {
-                        Thread.sleep(3000);
+                        Thread.sleep(6000);
                         commHandler.register("http://localhost:8080", null);
                         return;
                     }
@@ -102,8 +103,9 @@ public class DevServerComponent {
 
 
     @PreDestroy
-    public void stop() throws Exception {
-        Runtime rt = Runtime.getRuntime();
-        rt.exec("pkill inngest-cli");
+    public void stop()  {
+        if (devServerProcess != null && devServerProcess.isAlive()) {
+            devServerProcess.destroy();
+        }
     }
 }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DevModeIntrospectionTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DevModeIntrospectionTest.java
@@ -4,6 +4,8 @@ import com.inngest.InngestHeaderKey;
 import com.inngest.Version;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -12,15 +14,13 @@ import org.springframework.test.web.servlet.MockMvc;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Import(DemoTestConfiguration.class)
-@WebMvcTest(DemoController.class)
+@IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
 public class DevModeIntrospectionTest {
-
     @Autowired
     private MockMvc mockMvc;
 
     @Test
-    @EnabledIfSystemProperty(named = "test-group", matches = "unit-test")
     public void shouldReturnInsecureIntrospectPayload() throws Exception {
         mockMvc.perform(get("/api/inngest").header("Host", "localhost:8080"))
             .andExpect(status().isOk())


### PR DESCRIPTION


## Summary

There were two instances of the dev server being created at the same time by different tests tasks, causing one of the them to `pkill` both instances.

This PR fixes that along with tracking the dev server process and destroying it when tests are finish running.


<!-- A space for any related links, issues, or PRs. -->
<!-- Linear issues are autolinked. -->
<!-- e.g. - INN-123 -->
<!-- GitHub issues/PRs can be linked using shorthand. -->
<!-- e.g. "- inngest/inngest#123" -->
<!-- Feel free to remove this section if there are no applicable related links.-->

