### PR TITLE
Fix `step state incorrect type` when returning null from steps

### DIFF
--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/ReturnNullStepFunction.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/testfunctions/ReturnNullStepFunction.java
@@ -1,0 +1,23 @@
+package com.inngest.springbootdemo.testfunctions;
+
+import com.inngest.FunctionContext;
+import com.inngest.InngestFunction;
+import com.inngest.InngestFunctionConfigBuilder;
+import com.inngest.Step;
+import org.jetbrains.annotations.NotNull;
+
+public class ReturnNullStepFunction extends InngestFunction {
+    @NotNull
+    @Override
+    public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+        return builder
+            .id("null-step-fn")
+            .name("Function that has a step that returns null")
+            .triggerEvent("test/return.null.step");
+    }
+
+    @Override
+    public String execute(FunctionContext ctx, Step step) {
+        return step.run("null", () -> null, String.class);
+    }
+}

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DemoTestConfiguration.java
@@ -36,6 +36,7 @@ public class DemoTestConfiguration extends InngestConfiguration {
         addInngestFunction(functions, new LoopFunction());
         addInngestFunction(functions, new CancelOnEventFunction());
         addInngestFunction(functions, new CancelOnMatchFunction());
+        addInngestFunction(functions, new ReturnNullStepFunction());
 
         return functions;
     }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/ReturnNullStepIntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/ReturnNullStepIntegrationTest.java
@@ -1,0 +1,34 @@
+package com.inngest.springbootdemo;
+
+import com.inngest.Inngest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+
+@IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
+class ReturnNullStepIntegrationTest {
+    @Autowired
+    private DevServerComponent devServer;
+
+    @Autowired
+    private Inngest client;
+
+    @Test
+    void testReturnNullFromStep() throws Exception {
+        String eventId = InngestFunctionTestHelpers.sendEvent(client, "test/return.null.step").getIds()[0];
+
+        Thread.sleep(5000);
+
+        RunEntry<Object> run = devServer.runsByEvent(eventId).first();
+
+        assertEquals(eventId, run.getEvent_id());
+        assertEquals("Completed", run.getStatus());
+        assertNull(run.getOutput());
+    }
+}

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/ImageFromPrompt.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/ImageFromPrompt.kt
@@ -12,36 +12,8 @@ class ImageFromPrompt : InngestFunction() {
     override fun execute(
         ctx: FunctionContext,
         step: Step,
-    ): String {
-        val imageURL =
-            try {
-                step.run("generate-image-dall-e") {
-                    // Call the DALL-E model to generate an image
-                    throw Exception("Failed to generate image")
-
-                    "example.com/image-dall-e.jpg"
-                }
-            } catch (e: StepError) {
-                // Fall back to a different image generation model
-                step.run("generate-image-midjourney") {
-                    // Call the MidJourney model to generate an image
-                    "example.com/image-midjourney.jpg"
-                }
-            }
-
-        try {
-            step.invoke<Map<String, Any>>(
-                "push-to-slack-channel",
-                "ktor-dev",
-                "PushToSlackChannel",
-                mapOf("image" to imageURL),
-                null,
-            )
-        } catch (e: StepError) {
-            // Pushing to Slack is not critical, so we can ignore the error, log it
-            // or handle it in some other way.
+    ): String? =
+        step.run("generate-image-dall-e") {
+            null as String?
         }
-
-        return imageURL
-    }
 }

--- a/inngest/src/main/kotlin/com/inngest/Step.kt
+++ b/inngest/src/main/kotlin/com/inngest/Step.kt
@@ -102,10 +102,7 @@ class Step(
         val hashedId = state.getHashFromId(id)
 
         try {
-            val stepResult = state.getState(hashedId, type)
-            if (stepResult != null) {
-                return stepResult
-            }
+            return state.getState(hashedId, type) as T
         } catch (e: StateNotFound) {
             // If there is no existing result, run the lambda
             executeStep(id, hashedId, fn)


### PR DESCRIPTION
## Summary

Should fix the `step state incorrect type` that was being
thrown when a step returns a `null` result.

Changes:

* Allow returning a `null` value from the `data` field of a step for `step.run`.
* Make sure the `data` field is a `null` json node for `step.sleep`. Here's the memoized state payload sent to the JS sdk which the Kotlin code is closely following:

	```js
	await step.sleep("sleep", 100);
	await step.run("null", () => null);
	```
	```json
	{
	  "steps": {
	    "c3ca5f787365eae0dea86250e27d476406956478": null,
	    "244fb75b19415c9ee4f143b34b4b241236fb63f5": {
	      "data": null
	    }
	  }
	}
	```

## Checklist

<!-- Tick these items off as you progress. -->
<!-- If an item isn't applicable, ideally please strikeout the item by wrapping it in "~~"" and suffix it with "N/A My reason for skipping this." -->
<!-- e.g. "- [ ] ~~Added tests~~ N/A Only touches docs" -->

- [ ] Update documentation
- [x] Added unit/integration tests

## Related

https://inngest.slack.com/archives/C06KB85RXRV/p1736536607871969
