### PR TITLE
test(protocol): lock the SDK contract with protocol and adapter coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           github_token: ${{ secrets.github_token }}
           # NOTE: lock until this is resolved
           # https://github.com/ScaCap/action-ktlint/issues/48
-          ktlint_version: "1.1.1"
+          ktlint_version: "1.8.0"
           reporter: github-pr-review
 
   itest:

--- a/docs/plans/000-lock-contract-with-tests.org
+++ b/docs/plans/000-lock-contract-with-tests.org
@@ -14,20 +14,21 @@
 
 * Checklist
 - [X] Inventory current coverage in =inngest/src/test/kotlin= and identify missing protocol cases.
-- [ ] Extend sync request tests from the current Spring success/deployId coverage to include explicit failure-path assertions.
+- [X] Extend sync request tests from the current Spring success/deployId coverage to include explicit failure-path assertions.
 - [X] Add tests for introspection unauthenticated and authenticated payloads.
-- [ ] Add tests for call request success, retriable error, non-retriable error, and retry-after behavior.
-- [ ] Add tests asserting required response headers on call responses.
-- [ ] Add tests for step response payloads for =run=, =sleep=, =waitForEvent=, =invoke=, and =sendEvent=.
-- [ ] Add adapter tests proving Ktor and Spring route the same request semantics into shared core code.
-- [ ] Add fixtures/builders for execution request payloads to reduce copy-paste in later milestones.
+- [X] Add tests for call request success, retriable error, non-retriable error, and retry-after behavior.
+- [X] Add tests asserting required response headers on call responses.
+- [X] Add tests for step response payloads for =run=, =sleep=, =waitForEvent=, =invoke=, and =sendEvent=.
+- [X] Add adapter tests proving Ktor and Spring route the same request semantics into shared core code.
+- [X] Add fixtures/builders for execution request payloads to reduce copy-paste in later milestones.
 - [ ] Document any intentionally unsupported spec areas as skipped or pending tests.
 
 * Current Baseline
 - [X] Spring Boot route coverage exists for dev-mode introspection, cloud introspection with valid and invalid signatures, and sync registration deployId handling.
 - [X] Demo integration coverage now exercises async function behavior for idempotency, cancellation, retries, sendEvent, invoke, waitForEvent, sleep, debounce, rate limiting, and matrix-shaped payloads.
 - [X] Demo integration coverage also covers custom/null step results, deserialization, multi-step execution, and step error behavior.
-- [ ] Ktor route parity, call-response header assertions, and shared golden fixtures are still open.
+- [X] Shared protocol fixtures now drive =CommHandler= contract tests plus Ktor and Spring adapter route tests for call and sync behavior.
+- [ ] Explicit skipped coverage for intentionally unsupported protocol areas is still open.
 
 * Exit Criteria
 - [ ] Shared protocol behavior is covered by automated tests.

--- a/docs/plans/000-lock-contract-with-tests.org
+++ b/docs/plans/000-lock-contract-with-tests.org
@@ -1,16 +1,16 @@
 #+title: Lock Contract With Tests
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Active
+#+STATUS: Done
 
 * Goal
-- [ ] Freeze the current intended SDK contract in tests before broad refactors land.
-- [ ] Make spec regressions obvious in CI for sync, call handling, introspection, headers, and step responses.
+- [X] Freeze the current intended SDK contract in tests before broad refactors land.
+- [X] Make spec regressions obvious in CI for sync, call handling, introspection, headers, and step responses.
 
 * Scope
-- [ ] Add spec-driven unit tests for shared core behavior in =inngest=.
-- [ ] Add adapter coverage for both Ktor and Spring Boot request handling.
-- [ ] Add golden-style assertions for JSON wire shapes where stability matters.
+- [X] Add spec-driven unit tests for shared core behavior in =inngest=.
+- [X] Add adapter coverage for both Ktor and Spring Boot request handling.
+- [X] Add golden-style assertions for JSON wire shapes where stability matters.
 
 * Checklist
 - [X] Inventory current coverage in =inngest/src/test/kotlin= and identify missing protocol cases.
@@ -21,16 +21,16 @@
 - [X] Add tests for step response payloads for =run=, =sleep=, =waitForEvent=, =invoke=, and =sendEvent=.
 - [X] Add adapter tests proving Ktor and Spring route the same request semantics into shared core code.
 - [X] Add fixtures/builders for execution request payloads to reduce copy-paste in later milestones.
-- [ ] Document any intentionally unsupported spec areas as skipped or pending tests.
+- [X] Document any intentionally unsupported spec areas as skipped or pending tests.
 
 * Current Baseline
 - [X] Spring Boot route coverage exists for dev-mode introspection, cloud introspection with valid and invalid signatures, and sync registration deployId handling.
 - [X] Demo integration coverage now exercises async function behavior for idempotency, cancellation, retries, sendEvent, invoke, waitForEvent, sleep, debounce, rate limiting, and matrix-shaped payloads.
 - [X] Demo integration coverage also covers custom/null step results, deserialization, multi-step execution, and step error behavior.
 - [X] Shared protocol fixtures now drive =CommHandler= contract tests plus Ktor and Spring adapter route tests for call and sync behavior.
-- [ ] Explicit skipped coverage for intentionally unsupported protocol areas is still open.
+- [X] Explicit skipped coverage now documents unsupported areas such as in-band sync, =waitForEvent= match convenience, and planned-step opcodes.
 
 * Exit Criteria
-- [ ] Shared protocol behavior is covered by automated tests.
-- [ ] Ktor and Spring adapters have parity checks for their HTTP entrypoints.
-- [ ] The repo has stable fixtures that later milestones can extend instead of rebuilding payloads ad hoc.
+- [X] Shared protocol behavior is covered by automated tests.
+- [X] Ktor and Spring adapters have parity checks for their HTTP entrypoints.
+- [X] The repo has stable fixtures that later milestones can extend instead of rebuilding payloads ad hoc.

--- a/docs/plans/000-lock-contract-with-tests.org
+++ b/docs/plans/000-lock-contract-with-tests.org
@@ -14,7 +14,7 @@
 
 * Checklist
 - [X] Inventory current coverage in =inngest/src/test/kotlin= and identify missing protocol cases.
-- [ ] Add tests for sync request success and failure paths.
+- [ ] Extend sync request tests from the current Spring success/deployId coverage to include explicit failure-path assertions.
 - [X] Add tests for introspection unauthenticated and authenticated payloads.
 - [ ] Add tests for call request success, retriable error, non-retriable error, and retry-after behavior.
 - [ ] Add tests asserting required response headers on call responses.
@@ -25,7 +25,8 @@
 
 * Current Baseline
 - [X] Spring Boot route coverage exists for dev-mode introspection, cloud introspection with valid and invalid signatures, and sync registration deployId handling.
-- [X] Demo integration coverage now exercises async function behavior for idempotency, cancellation, retries, sendEvent, invoke, waitForEvent, and matrix-shaped payloads.
+- [X] Demo integration coverage now exercises async function behavior for idempotency, cancellation, retries, sendEvent, invoke, waitForEvent, sleep, debounce, rate limiting, and matrix-shaped payloads.
+- [X] Demo integration coverage also covers custom/null step results, deserialization, multi-step execution, and step error behavior.
 - [ ] Ktor route parity, call-response header assertions, and shared golden fixtures are still open.
 
 * Exit Criteria

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776169885,
-        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
         "type": "github"
       },
       "original": {

--- a/inngest-spring-boot-adapter/build.gradle.kts
+++ b/inngest-spring-boot-adapter/build.gradle.kts
@@ -27,7 +27,9 @@ dependencies {
     api(pkg)
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    testImplementation(testFixtures(project(":inngest")))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }
 
 dependencyManagement {

--- a/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
+++ b/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
@@ -4,6 +4,7 @@ import com.inngest.CommHandler;
 import com.inngest.CommResponse;
 import com.inngest.InngestEnv;
 import com.inngest.InngestQueryParamKey;
+import com.inngest.SyncResponse;
 import com.inngest.signingkey.SignatureVerificationKt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -43,14 +44,23 @@ public abstract class InngestController {
     @PutMapping()
     public ResponseEntity<String> put(
         @RequestHeader(HttpHeaders.HOST) String hostHeader,
+        @RequestHeader(name = "X-Inngest-Server-Kind", required = false) String serverKind,
         HttpServletRequest request
     ) {
         String origin = String.format("%s://%s", request.getScheme(), hostHeader);
         if (this.serveOrigin != null && !this.serveOrigin.isEmpty()) {
             origin = this.serveOrigin;
         }
-        String response = commHandler.register(origin, request.getParameter(InngestQueryParamKey.SyncId.getValue()));
-        return ResponseEntity.ok().headers(getHeaders()).body(response);
+        SyncResponse response = commHandler.register(
+            origin,
+            request.getParameter(InngestQueryParamKey.SyncId.getValue()),
+            serverKind
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        response.getHeaders().forEach(headers::add);
+
+        return ResponseEntity.status(response.getStatusCode()).headers(headers).body(response.getBody());
     }
 
     @PostMapping()

--- a/inngest-spring-boot-adapter/src/test/java/com/inngest/springboot/InngestControllerTest.java
+++ b/inngest-spring-boot-adapter/src/test/java/com/inngest/springboot/InngestControllerTest.java
@@ -1,0 +1,148 @@
+package com.inngest.springboot;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.inngest.CommHandler;
+import com.inngest.FunctionContext;
+import com.inngest.Inngest;
+import com.inngest.InngestFunction;
+import com.inngest.InngestFunctionConfigBuilder;
+import com.inngest.InngestHeaderKey;
+import com.inngest.ServeConfig;
+import com.inngest.Step;
+import com.inngest.SupportedFrameworkName;
+import com.inngest.testing.ProtocolFixtures;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class InngestControllerTest {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final HashMap<String, InngestFunction> FUNCTIONS = new HashMap<>();
+
+    static {
+        FUNCTIONS.put("echo-fn", new EchoFunction());
+    }
+
+    private MockMvc mockMvc;
+
+    private MockWebServer mockWebServer;
+
+    @BeforeEach
+    void setUp() {
+        TestController controller = new TestController();
+        Inngest client = new Inngest("test-app", null, "evt-key", null, true);
+        controller.commHandler = new CommHandler(FUNCTIONS, client, new ServeConfig(client), SupportedFrameworkName.SpringBoot);
+        mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        System.clearProperty("INNGEST_API_BASE_URL");
+        if (mockWebServer != null) {
+            mockWebServer.shutdown();
+            mockWebServer = null;
+        }
+    }
+
+    @Test
+    void postRouteReturnsCallResponseWithRequiredHeaders() throws Exception {
+        String responseBody = mockMvc.perform(post("/api/inngest")
+                .queryParam("fnId", "echo-fn")
+                .contentType("application/json")
+                .content(ProtocolFixtures.executionRequestPayloadJson("echo-fn")))
+            .andExpect(status().isOk())
+            .andExpect(header().string(InngestHeaderKey.RequestVersion.getValue(), "2"))
+            .andExpect(header().string(InngestHeaderKey.Framework.getValue(), "springboot"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        assertEquals("\"done\"", responseBody);
+    }
+
+    @Test
+    void putRouteReturnsSuccessfulSyncResponseAndForwardsExpectedServerKind() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.enqueue(new MockResponse().setBody("{\"ok\":true,\"modified\":true}"));
+        mockWebServer.start();
+        System.setProperty(
+            "INNGEST_API_BASE_URL",
+            mockWebServer.url("").toString().substring(0, mockWebServer.url("").toString().length() - 1)
+        );
+
+        String responseBody = mockMvc.perform(put("/api/inngest")
+                .header("Host", "localhost:8080")
+                .header(InngestHeaderKey.ServerKind.getValue(), "cloud")
+                .param("deployId", "deploy-1"))
+            .andExpect(status().isOk())
+            .andExpect(header().string(InngestHeaderKey.RequestVersion.getValue(), "2"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        JsonNode body = MAPPER.readTree(responseBody);
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+
+        assertEquals("Successfully synced.", body.get("message").asText());
+        assertTrue(body.get("modified").asBoolean());
+        assertEquals("/fn/register?deployId=deploy-1", recordedRequest.getPath());
+        assertEquals("cloud", recordedRequest.getHeader(InngestHeaderKey.ExpectedServerKind.getValue()));
+        assertEquals("2", recordedRequest.getHeader(InngestHeaderKey.RequestVersion.getValue()));
+    }
+
+    @Test
+    void putRouteReturnsSyncFailurePayloadWhenRegisterFails() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.enqueue(new MockResponse().setResponseCode(400).setBody("{\"error\":\"invalid config\"}"));
+        mockWebServer.start();
+        System.setProperty(
+            "INNGEST_API_BASE_URL",
+            mockWebServer.url("").toString().substring(0, mockWebServer.url("").toString().length() - 1)
+        );
+
+        String responseBody = mockMvc.perform(put("/api/inngest")
+                .header("Host", "localhost:8080"))
+            .andExpect(status().isInternalServerError())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        JsonNode body = MAPPER.readTree(responseBody);
+        assertEquals("invalid config", body.get("message").asText());
+        assertEquals(false, body.get("modified").asBoolean());
+    }
+
+    @RestController
+    @RequestMapping("/api/inngest")
+    static class TestController extends InngestController {
+    }
+
+    static class EchoFunction extends InngestFunction {
+        @Override
+        public InngestFunctionConfigBuilder config(InngestFunctionConfigBuilder builder) {
+            return builder.id("echo-fn");
+        }
+
+        @Override
+        public Object execute(FunctionContext ctx, Step step) {
+            return "done";
+        }
+    }
+}

--- a/inngest/build.gradle.kts
+++ b/inngest/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     testFixturesImplementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
 
     testImplementation(kotlin("test"))
+    testImplementation("io.ktor:ktor-server-test-host:2.3.5")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.junit-pioneer:junit-pioneer:1.9.1")
 }

--- a/inngest/build.gradle.kts
+++ b/inngest/build.gradle.kts
@@ -7,6 +7,7 @@ version = file("VERSION").readText().trim()
 
 plugins {
     id("java-library")
+    id("java-test-fixtures")
     id("maven-publish")
     id("signing")
     id("org.jetbrains.kotlin.jvm") version "1.9.10"
@@ -33,7 +34,10 @@ dependencies {
 
     implementation("io.ktor:ktor-server-core:2.3.5")
 
+    testFixturesImplementation("com.fasterxml.jackson.core:jackson-databind:2.16.1")
+
     testImplementation(kotlin("test"))
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testImplementation("org.junit-pioneer:junit-pioneer:1.9.1")
 }
 

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -230,9 +230,11 @@ class CommHandler(
 
         val requestPayload =
             when (client.env) {
-                InngestEnv.Dev -> insecureIntrospection
+                InngestEnv.Dev -> {
+                    insecureIntrospection
+                }
 
-                else ->
+                else -> {
                     runCatching {
                         checkHeadersAndValidateSignature(signature, requestBody, serverKind, config)
 
@@ -257,6 +259,7 @@ class CommHandler(
                     }.getOrElse {
                         insecureIntrospection.apply { authenticationSucceeded = false }
                     }
+                }
             }
 
         return serializePayload(requestPayload)
@@ -291,11 +294,19 @@ class CommHandler(
 
     private fun syncFailureMessage(responseBody: String): String? =
         runCatching {
-            ObjectMapper().readTree(responseBody).path("error").takeIf { !it.isMissingNode && !it.isNull }?.asText()
+            ObjectMapper()
+                .readTree(responseBody)
+                .path("error")
+                .takeIf { !it.isMissingNode && !it.isNull }
+                ?.asText()
         }.getOrNull()
 
     private fun syncModified(responseBody: String): Boolean =
         runCatching {
-            ObjectMapper().readTree(responseBody).path("modified").takeIf { !it.isMissingNode && !it.isNull }?.asBoolean() ?: false
+            ObjectMapper()
+                .readTree(responseBody)
+                .path("modified")
+                .takeIf { !it.isMissingNode && !it.isNull }
+                ?.asBoolean() ?: false
         }.getOrDefault(false)
 }

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.inngest.signingkey.checkHeadersAndValidateSignature
 import com.inngest.signingkey.getAuthorizationHeader
 import com.inngest.signingkey.hashedSigningKey
-import java.io.IOException
 import java.security.MessageDigest
 
 data class ExecutionRequestPayload(
@@ -43,6 +42,12 @@ internal data class RegistrationRequestPayload
 data class CommResponse(
     val body: String,
     val statusCode: ResultStatusCode,
+    val headers: Map<String, String>,
+)
+
+data class SyncResponse(
+    val body: String,
+    val statusCode: Int,
     val headers: Map<String, String>,
 )
 
@@ -152,34 +157,59 @@ class CommHandler(
         return configs
     }
 
+    @JvmOverloads
     fun register(
         origin: String,
         syncId: String?,
-    ): String {
+        expectedServerKind: String? = null,
+    ): SyncResponse {
         val registrationUrl = "${config.baseUrl()}/fn/register"
         val requestPayload = getRegistrationRequestPayload(origin)
 
         val httpClient = client.httpClient
 
         val signingKey = config.signingKey()
-        val authorizationHeaderRequestConfig =
-            if (config.client.env != InngestEnv.Dev) {
-                RequestConfig(getAuthorizationHeader(signingKey))
-            } else {
-                null
-            }
-
-        val queryParams = syncId?.let { mapOf(InngestQueryParamKey.SyncId.value to it) } ?: emptyMap()
-
-        val request = httpClient.build(registrationUrl, requestPayload, queryParams, authorizationHeaderRequestConfig)
-
-        httpClient.send(request) { response ->
-            if (!response.isSuccessful) throw IOException("Unexpected code $response")
+        val requestHeaders = mutableMapOf<String, String>()
+        if (config.client.env != InngestEnv.Dev) {
+            requestHeaders.putAll(getAuthorizationHeader(signingKey))
+        }
+        if (expectedServerKind != null) {
+            requestHeaders[InngestHeaderKey.ExpectedServerKind.value] = expectedServerKind
         }
 
-        // TODO - Add headers to output
-        val body: Map<String, Any?> = mapOf()
-        return parseRequestBody(body)
+        val queryParams = syncId?.let { mapOf(InngestQueryParamKey.SyncId.value to it) } ?: emptyMap()
+        val requestConfig = if (requestHeaders.isEmpty()) null else RequestConfig(requestHeaders)
+
+        val request = httpClient.build(registrationUrl, requestPayload, queryParams, requestConfig)
+
+        return httpClient.send(request) { response ->
+            val responseBody = response.body?.string().orEmpty()
+            if (!response.isSuccessful) {
+                return@send SyncResponse(
+                    body =
+                        parseRequestBody(
+                            mapOf(
+                                "message" to (syncFailureMessage(responseBody) ?: "Unexpected code $response"),
+                                "modified" to false,
+                            ),
+                        ),
+                    statusCode = 500,
+                    headers = headers,
+                )
+            }
+
+            SyncResponse(
+                body =
+                    parseRequestBody(
+                        mapOf(
+                            "message" to "Successfully synced.",
+                            "modified" to syncModified(responseBody),
+                        ),
+                    ),
+                statusCode = 200,
+                headers = headers,
+            )
+        }
     }
 
     // TODO
@@ -258,4 +288,14 @@ class CommHandler(
                     .digest(it.toByteArray())
                     .joinToString("") { byte -> "%02x".format(byte) }
             }
+
+    private fun syncFailureMessage(responseBody: String): String? =
+        runCatching {
+            ObjectMapper().readTree(responseBody).path("error").takeIf { !it.isMissingNode && !it.isNull }?.asText()
+        }.getOrNull()
+
+    private fun syncModified(responseBody: String): Boolean =
+        runCatching {
+            ObjectMapper().readTree(responseBody).path("modified").takeIf { !it.isMissingNode && !it.isNull }?.asBoolean() ?: false
+        }.getOrDefault(false)
 }

--- a/inngest/src/main/kotlin/com/inngest/Environment.kt
+++ b/inngest/src/main/kotlin/com/inngest/Environment.kt
@@ -9,6 +9,7 @@ object Environment {
             InngestHeaderKey.ContentType.value to "application/json",
             InngestHeaderKey.Sdk.value to sdk,
             InngestHeaderKey.UserAgent.value to sdk,
+            InngestHeaderKey.RequestVersion.value to "2",
             InngestHeaderKey.Framework.value to (framework?.value),
         ).filterValues { (it is String) }.entries.associate { (k, v) -> k to v!! }
     }

--- a/inngest/src/main/kotlin/com/inngest/Environment.kt
+++ b/inngest/src/main/kotlin/com/inngest/Environment.kt
@@ -59,8 +59,14 @@ object Environment {
         val sysDev = systemValue(InngestSystem.Dev.value)
         if (sysDev != null) {
             return when (sysDev) {
-                "0" -> InngestEnv.Prod
-                "1" -> InngestEnv.Dev
+                "0" -> {
+                    InngestEnv.Prod
+                }
+
+                "1" -> {
+                    InngestEnv.Dev
+                }
+
                 else -> {
                     val other = InngestEnv.Other
                     other.value = sysDev
@@ -71,10 +77,22 @@ object Environment {
 
         if (env != null) {
             return when (env) {
-                "dev" -> InngestEnv.Dev
-                "development" -> InngestEnv.Dev
-                "prod" -> InngestEnv.Prod
-                "production" -> InngestEnv.Prod
+                "dev" -> {
+                    InngestEnv.Dev
+                }
+
+                "development" -> {
+                    InngestEnv.Dev
+                }
+
+                "prod" -> {
+                    InngestEnv.Prod
+                }
+
+                "production" -> {
+                    InngestEnv.Prod
+                }
+
                 else -> {
                     val other = InngestEnv.Other
                     other.value = env
@@ -85,11 +103,25 @@ object Environment {
 
         // Read from environment variable
         return when (val inngestEnv = systemValue(InngestSystem.Env.value)) {
-            null -> InngestEnv.Dev
-            "dev" -> InngestEnv.Dev
-            "development" -> InngestEnv.Dev
-            "prod" -> InngestEnv.Prod
-            "production" -> InngestEnv.Prod
+            null -> {
+                InngestEnv.Dev
+            }
+
+            "dev" -> {
+                InngestEnv.Dev
+            }
+
+            "development" -> {
+                InngestEnv.Dev
+            }
+
+            "prod" -> {
+                InngestEnv.Prod
+            }
+
+            "production" -> {
+                InngestEnv.Prod
+            }
 
             else -> {
                 val other = InngestEnv.Other

--- a/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
+++ b/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
@@ -103,15 +103,14 @@ class InngestFunctionConfigBuilder {
         event: String,
         `if`: String? = null,
         timeout: Duration? = null,
-    ): InngestFunctionConfigBuilder {
-        return cancelOn(
+    ): InngestFunctionConfigBuilder =
+        cancelOn(
             Cancellation(
                 event,
                 `if`,
                 timeout?.let { durationConverter.toJson(it) },
             ),
         )
-    }
 
     /**
      * Define events that can be used to cancel a running or sleeping function
@@ -129,15 +128,14 @@ class InngestFunctionConfigBuilder {
         event: String,
         `if`: String? = null,
         timeout: Instant? = null,
-    ): InngestFunctionConfigBuilder {
-        return cancelOn(
+    ): InngestFunctionConfigBuilder =
+        cancelOn(
             Cancellation(
                 event,
                 `if`,
                 timeout?.let { timeout.toString() },
             ),
         )
-    }
 
     internal fun cancelOn(cancellation: Cancellation): InngestFunctionConfigBuilder =
         apply {
@@ -180,15 +178,20 @@ class InngestFunctionConfigBuilder {
         scope: ConcurrencyScope? = null,
     ): InngestFunctionConfigBuilder {
         when (scope) {
-            ConcurrencyScope.ENVIRONMENT ->
+            ConcurrencyScope.ENVIRONMENT -> {
                 if (key == null) {
                     throw InngestInvalidConfigurationException("Concurrency key required with environment scope")
                 }
-            ConcurrencyScope.ACCOUNT ->
+            }
+
+            ConcurrencyScope.ACCOUNT -> {
                 if (key == null) {
                     throw InngestInvalidConfigurationException("Concurrency key required with account scope")
                 }
+            }
+
             ConcurrencyScope.FUNCTION -> {}
+
             null -> {}
         }
 
@@ -345,8 +348,7 @@ val durationConverter =
         override fun canConvert(cls: Class<*>): Boolean = cls == Duration::class.java
 
         // TODO Implement this - parse 30s into duration of seconds
-        override fun fromJson(jv: JsonValue): Duration =
-            throw KlaxonException("Duration parse not implemented: ${jv.string}")
+        override fun fromJson(jv: JsonValue): Duration = throw KlaxonException("Duration parse not implemented: ${jv.string}")
 
         override fun toJson(value: Any): String = """"${(value as Duration).seconds}s""""
     }

--- a/inngest/src/main/kotlin/com/inngest/RetryDecision.kt
+++ b/inngest/src/main/kotlin/com/inngest/RetryDecision.kt
@@ -7,16 +7,21 @@ internal data class RetryDecision(
     companion object {
         internal fun fromException(exception: Exception): RetryDecision =
             when (exception) {
-                is RetryAfterError ->
+                is RetryAfterError -> {
                     RetryDecision(
                         true,
                         mapOf(InngestHeaderKey.RetryAfter.value to exception.retryAfter, noRetryFalse),
                     )
+                }
 
-                is NonRetriableError -> RetryDecision(false, mapOf(InngestHeaderKey.NoRetry.value to "true"))
+                is NonRetriableError -> {
+                    RetryDecision(false, mapOf(InngestHeaderKey.NoRetry.value to "true"))
+                }
 
                 // Any other error should have the default retry behavior.
-                else -> RetryDecision(true, mapOf(noRetryFalse))
+                else -> {
+                    RetryDecision(true, mapOf(noRetryFalse))
+                }
             }
     }
 }

--- a/inngest/src/main/kotlin/com/inngest/ServeConfig.kt
+++ b/inngest/src/main/kotlin/com/inngest/ServeConfig.kt
@@ -23,7 +23,10 @@ class ServeConfig
             if (signingKey != null) return signingKey
 
             return when (client.env) {
-                InngestEnv.Dev -> DUMMY_SIGNING_KEY
+                InngestEnv.Dev -> {
+                    DUMMY_SIGNING_KEY
+                }
+
                 else -> {
                     val signingKey =
                         System.getProperty(InngestSystem.SigningKey.value)

--- a/inngest/src/main/kotlin/com/inngest/State.kt
+++ b/inngest/src/main/kotlin/com/inngest/State.kt
@@ -63,9 +63,12 @@ class State(
 
         return when {
             stepResult.has(fieldName) -> deserializeStepData(stepResult.get(fieldName), type)
+
             stepResult.has("error") -> throw mapper.treeToValue(stepResult.get("error"), StepError::class.java)
+
             // NOTE - Sleep steps will be stored as null
             stepResult is NullNode -> null
+
             else -> throw Exception("Unexpected step data structure")
         }
     }

--- a/inngest/src/main/kotlin/com/inngest/ktor/Route.kt
+++ b/inngest/src/main/kotlin/com/inngest/ktor/Route.kt
@@ -1,6 +1,7 @@
 package com.inngest.ktor
 
 import com.inngest.*
+import com.inngest.signingkey.checkHeadersAndValidateSignature
 import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.plugins.*
@@ -59,6 +60,10 @@ fun Route.serve(
             } else {
                 val body = call.receiveText()
                 try {
+                    val signature = call.request.headers[InngestHeaderKey.Signature.value]
+                    val serverKind = call.request.headers[InngestHeaderKey.ServerKind.value]
+                    checkHeadersAndValidateSignature(signature, body, serverKind, comm.config)
+
                     val response = comm.callFunction(fnId, body)
                     response.headers.forEach({ (k, v) -> call.response.header(k, v) })
                     call.response.status(
@@ -73,10 +78,12 @@ fun Route.serve(
 
         put("") {
             val syncId = call.request.queryParameters[InngestQueryParamKey.SyncId.value]
+            val serverKind = call.request.headers[InngestHeaderKey.ServerKind.value]
 
             val origin = getOrigin(call)
-            val resp = comm.register(origin, syncId)
-            call.respond(HttpStatusCode.OK, resp)
+            val response = comm.register(origin, syncId, serverKind)
+            response.headers.forEach { (k, v) -> call.response.header(k, v) }
+            call.respondText(response.body, ContentType.Application.Json, HttpStatusCode.fromValue(response.statusCode))
         }
     }
 }

--- a/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
@@ -68,12 +68,8 @@ internal class CommHandlerTest {
             commHandler(RunStepFunction())
                 .callFunction("run-step-fn", ProtocolFixtures.executionRequestPayloadJson("run-step-fn"))
 
-        val step = firstStep(response)
-
         assertEquals(ResultStatusCode.StepComplete, response.statusCode)
-        assertEquals("StepRun", step["op"].asText())
-        assertEquals("compute", step["name"].asText())
-        assertEquals(42, step["data"].asInt())
+        assertStepMatchesGolden(response, "protocol/steps/run-step.json")
     }
 
     @Test
@@ -82,12 +78,8 @@ internal class CommHandlerTest {
             commHandler(SleepStepFunction())
                 .callFunction("sleep-step-fn", ProtocolFixtures.executionRequestPayloadJson("sleep-step-fn"))
 
-        val step = firstStep(response)
-
         assertEquals(ResultStatusCode.StepComplete, response.statusCode)
-        assertEquals("Sleep", step["op"].asText())
-        assertEquals("pause", step["name"].asText())
-        assertEquals("9s", step["opts"]["duration"].asText())
+        assertStepMatchesGolden(response, "protocol/steps/sleep-step.json")
     }
 
     @Test
@@ -96,14 +88,8 @@ internal class CommHandlerTest {
             commHandler(WaitForEventStepFunction())
                 .callFunction("wait-step-fn", ProtocolFixtures.executionRequestPayloadJson("wait-step-fn"))
 
-        val step = firstStep(response)
-
         assertEquals(ResultStatusCode.StepComplete, response.statusCode)
-        assertEquals("WaitForEvent", step["op"].asText())
-        assertEquals("wait-for-user", step["name"].asText())
-        assertEquals("app/user.updated", step["opts"]["event"].asText())
-        assertEquals("10m", step["opts"]["timeout"].asText())
-        assertEquals("event.data.userId == async.data.userId", step["opts"]["if"].asText())
+        assertStepMatchesGolden(response, "protocol/steps/wait-for-event-step.json")
     }
 
     @Test
@@ -112,14 +98,8 @@ internal class CommHandlerTest {
             commHandler(InvokeStepFunction())
                 .callFunction("invoke-step-fn", ProtocolFixtures.executionRequestPayloadJson("invoke-step-fn"))
 
-        val step = firstStep(response)
-
         assertEquals(ResultStatusCode.StepComplete, response.statusCode)
-        assertEquals("InvokeFunction", step["op"].asText())
-        assertEquals("invoke-user", step["name"].asText())
-        assertEquals("target-app-target-fn", step["opts"]["function_id"].asText())
-        assertEquals("123", step["opts"]["payload"]["data"]["userId"].asText())
-        assertEquals("30s", step["opts"]["timeout"].asText())
+        assertStepMatchesGolden(response, "protocol/steps/invoke-step.json")
     }
 
     @Test
@@ -133,12 +113,8 @@ internal class CommHandlerTest {
             commHandler(SendEventStepFunction(), baseUrl = baseUrl)
                 .callFunction("send-step-fn", ProtocolFixtures.executionRequestPayloadJson("send-step-fn"))
 
-        val step = firstStep(response)
-
         assertEquals(ResultStatusCode.StepComplete, response.statusCode)
-        assertEquals("Step", step["op"].asText())
-        assertEquals("send-user", step["name"].asText())
-        assertEquals("evt-1", step["data"]["event_ids"][0].asText())
+        assertStepMatchesGolden(response, "protocol/steps/send-event-step.json")
     }
 
     private fun commHandler(
@@ -167,6 +143,19 @@ internal class CommHandlerTest {
         assertEquals(1, body.size())
         return body[0]
     }
+
+    private fun assertStepMatchesGolden(
+        response: CommResponse,
+        resourcePath: String,
+    ) {
+        assertEquals(loadGoldenJson(resourcePath), firstStep(response))
+    }
+
+    private fun loadGoldenJson(resourcePath: String): JsonNode =
+        mapper.readTree(
+            javaClass.classLoader.getResourceAsStream(resourcePath)
+                ?: error("Missing golden fixture: $resourcePath"),
+        )
 
     private class EchoFunction : InngestFunction() {
         override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("echo-fn")

--- a/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
@@ -1,0 +1,248 @@
+package com.inngest
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.inngest.testing.ProtocolFixtures
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+internal class CommHandlerTest {
+    private val mapper = ObjectMapper()
+    private var mockWebServer: MockWebServer? = null
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer?.shutdown()
+        mockWebServer = null
+    }
+
+    @Test
+    fun `callFunction returns success payload with required headers`() {
+        val response =
+            commHandler(EchoFunction())
+                .callFunction("echo-fn", ProtocolFixtures.executionRequestPayloadJson("echo-fn"))
+
+        assertEquals(ResultStatusCode.FunctionComplete, response.statusCode)
+        assertEquals("2", response.headers[InngestHeaderKey.RequestVersion.value])
+        assertEquals("springboot", response.headers[InngestHeaderKey.Framework.value])
+        assertTrue(response.headers[InngestHeaderKey.Sdk.value]!!.startsWith("inngest-kt:v"))
+        assertEquals("done", mapper.readValue(response.body, String::class.java))
+    }
+
+    @Test
+    fun `callFunction marks non-retriable errors correctly`() {
+        val response =
+            commHandler(NonRetriableFailureFunction())
+                .callFunction("non-retriable-fn", ProtocolFixtures.executionRequestPayloadJson("non-retriable-fn"))
+
+        val body = mapper.readTree(response.body)
+
+        assertEquals(ResultStatusCode.NonRetriableError, response.statusCode)
+        assertEquals("true", response.headers[InngestHeaderKey.NoRetry.value])
+        assertEquals("2", response.headers[InngestHeaderKey.RequestVersion.value])
+        assertEquals("hard failure", body["message"].asText())
+    }
+
+    @Test
+    fun `callFunction propagates retry-after headers for retriable errors`() {
+        val response =
+            commHandler(RetryAfterFailureFunction())
+                .callFunction("retry-after-fn", ProtocolFixtures.executionRequestPayloadJson("retry-after-fn"))
+
+        val body = mapper.readTree(response.body)
+
+        assertEquals(ResultStatusCode.RetriableError, response.statusCode)
+        assertEquals("false", response.headers[InngestHeaderKey.NoRetry.value])
+        assertEquals("5", response.headers[InngestHeaderKey.RetryAfter.value])
+        assertEquals("retry later", body["message"].asText())
+    }
+
+    @Test
+    fun `callFunction returns run step payload`() {
+        val response =
+            commHandler(RunStepFunction())
+                .callFunction("run-step-fn", ProtocolFixtures.executionRequestPayloadJson("run-step-fn"))
+
+        val step = firstStep(response)
+
+        assertEquals(ResultStatusCode.StepComplete, response.statusCode)
+        assertEquals("StepRun", step["op"].asText())
+        assertEquals("compute", step["name"].asText())
+        assertEquals(42, step["data"].asInt())
+    }
+
+    @Test
+    fun `callFunction returns sleep step payload`() {
+        val response =
+            commHandler(SleepStepFunction())
+                .callFunction("sleep-step-fn", ProtocolFixtures.executionRequestPayloadJson("sleep-step-fn"))
+
+        val step = firstStep(response)
+
+        assertEquals(ResultStatusCode.StepComplete, response.statusCode)
+        assertEquals("Sleep", step["op"].asText())
+        assertEquals("pause", step["name"].asText())
+        assertEquals("9s", step["opts"]["duration"].asText())
+    }
+
+    @Test
+    fun `callFunction returns waitForEvent payload`() {
+        val response =
+            commHandler(WaitForEventStepFunction())
+                .callFunction("wait-step-fn", ProtocolFixtures.executionRequestPayloadJson("wait-step-fn"))
+
+        val step = firstStep(response)
+
+        assertEquals(ResultStatusCode.StepComplete, response.statusCode)
+        assertEquals("WaitForEvent", step["op"].asText())
+        assertEquals("wait-for-user", step["name"].asText())
+        assertEquals("app/user.updated", step["opts"]["event"].asText())
+        assertEquals("10m", step["opts"]["timeout"].asText())
+        assertEquals("event.data.userId == async.data.userId", step["opts"]["if"].asText())
+    }
+
+    @Test
+    fun `callFunction returns invoke payload`() {
+        val response =
+            commHandler(InvokeStepFunction())
+                .callFunction("invoke-step-fn", ProtocolFixtures.executionRequestPayloadJson("invoke-step-fn"))
+
+        val step = firstStep(response)
+
+        assertEquals(ResultStatusCode.StepComplete, response.statusCode)
+        assertEquals("InvokeFunction", step["op"].asText())
+        assertEquals("invoke-user", step["name"].asText())
+        assertEquals("target-app-target-fn", step["opts"]["function_id"].asText())
+        assertEquals("123", step["opts"]["payload"]["data"]["userId"].asText())
+        assertEquals("30s", step["opts"]["timeout"].asText())
+    }
+
+    @Test
+    fun `callFunction returns sendEvent payload`() {
+        val server = MockWebServer()
+        mockWebServer = server
+        server.enqueue(MockResponse().setBody("""{"ids":["evt-1"]}"""))
+
+        val baseUrl = server.url("").toString().removeSuffix("/")
+        val response =
+            commHandler(SendEventStepFunction(), baseUrl = baseUrl)
+                .callFunction("send-step-fn", ProtocolFixtures.executionRequestPayloadJson("send-step-fn"))
+
+        val step = firstStep(response)
+
+        assertEquals(ResultStatusCode.StepComplete, response.statusCode)
+        assertEquals("Step", step["op"].asText())
+        assertEquals("send-user", step["name"].asText())
+        assertEquals("evt-1", step["data"]["event_ids"][0].asText())
+    }
+
+    private fun commHandler(
+        function: InngestFunction,
+        baseUrl: String? = null,
+    ): CommHandler {
+        val client =
+            Inngest(
+                appId = "test-app",
+                baseUrl = baseUrl,
+                eventKey = "evt-key",
+                isDev = true,
+            )
+
+        return CommHandler(
+            functions = mapOf(function.id() to function),
+            client = client,
+            config = ServeConfig(client, baseUrl = baseUrl),
+            framework = SupportedFrameworkName.SpringBoot,
+        )
+    }
+
+    private fun firstStep(response: CommResponse): JsonNode {
+        val body = mapper.readTree(response.body)
+        assertTrue(body.isArray)
+        assertEquals(1, body.size())
+        return body[0]
+    }
+
+    private class EchoFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("echo-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ): Any = "done"
+    }
+
+    private class NonRetriableFailureFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("non-retriable-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ): Any? = throw NonRetriableError("hard failure")
+    }
+
+    private class RetryAfterFailureFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("retry-after-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ): Any? = throw RetryAfterError("retry later", 5000)
+    }
+
+    private class RunStepFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("run-step-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ): Any = step.run("compute") { 42 }
+    }
+
+    private class SleepStepFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("sleep-step-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ) {
+            step.sleep("pause", Duration.ofSeconds(9))
+        }
+    }
+
+    private class WaitForEventStepFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("wait-step-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ): Any? = step.waitForEvent("wait-for-user", "app/user.updated", "10m", "event.data.userId == async.data.userId")
+    }
+
+    private class InvokeStepFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("invoke-step-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ): Any = step.invoke<String>("invoke-user", "target-app", "target-fn", mapOf("userId" to "123"), "30s")
+    }
+
+    private class SendEventStepFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("send-step-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ): Any =
+            step.sendEvent(
+                "send-user",
+                InngestEvent("app/user.created", ProtocolFixtures.linkedData("userId", "123")),
+            )
+    }
+}

--- a/inngest/src/test/kotlin/com/inngest/ProtocolGapsTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/ProtocolGapsTest.kt
@@ -1,0 +1,21 @@
+package com.inngest
+
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+
+internal class ProtocolGapsTest {
+    @Test
+    @Disabled("In-band sync is not implemented yet; sync is still performed as a separate POST /fn/register handshake.")
+    fun `in-band sync remains intentionally unsupported`() {
+    }
+
+    @Test
+    @Disabled("waitForEvent supports the if-expression form only; the match convenience API is still pending.")
+    fun `waitForEvent match convenience remains intentionally unsupported`() {
+    }
+
+    @Test
+    @Disabled("The SDK does not yet implement StepPlanned and StepNotFound opcodes for planned-step execution.")
+    fun `planned step opcodes remain intentionally unsupported`() {
+    }
+}

--- a/inngest/src/test/kotlin/com/inngest/ktor/RouteTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/ktor/RouteTest.kt
@@ -1,0 +1,131 @@
+package com.inngest.ktor
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.inngest.FunctionContext
+import com.inngest.Inngest
+import com.inngest.InngestFunction
+import com.inngest.InngestFunctionConfigBuilder
+import com.inngest.InngestHeaderKey
+import com.inngest.Step
+import com.inngest.testing.ProtocolFixtures
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.put
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class RouteTest {
+    private val mapper = ObjectMapper()
+    private var mockWebServer: MockWebServer? = null
+
+    @AfterEach
+    fun tearDown() {
+        mockWebServer?.shutdown()
+        mockWebServer = null
+    }
+
+    @Test
+    fun `post route returns call response with required headers`() =
+        testApplication {
+            application {
+                routing {
+                    serve("/api/inngest", Inngest("test-app", eventKey = "evt-key", isDev = true), listOf(EchoFunction()))
+                }
+            }
+
+            val response =
+                client.post("/api/inngest?fnId=echo-fn") {
+                    contentType(ContentType.Application.Json)
+                    setBody(ProtocolFixtures.executionRequestPayloadJson("echo-fn"))
+                }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("2", response.headers[InngestHeaderKey.RequestVersion.value])
+            assertEquals("ktor", response.headers[InngestHeaderKey.Framework.value])
+            assertEquals("\"done\"", response.bodyAsText())
+        }
+
+    @Test
+    fun `put route returns successful sync response and forwards expected server kind`() =
+        testApplication {
+            val server = MockWebServer()
+            mockWebServer = server
+            server.enqueue(MockResponse().setBody("""{"ok":true,"modified":true}"""))
+
+            val apiBaseUrl = server.url("").toString().removeSuffix("/")
+
+            application {
+                routing {
+                    serve(
+                        path = "/api/inngest",
+                        client = Inngest("test-app", eventKey = "evt-key", isDev = true),
+                        fnList = listOf(EchoFunction()),
+                        baseUrl = apiBaseUrl,
+                    )
+                }
+            }
+
+            val response =
+                client.put("/api/inngest?deployId=deploy-1") {
+                    header(InngestHeaderKey.ServerKind.value, "cloud")
+                }
+
+            val body = mapper.readTree(response.bodyAsText())
+            val recordedRequest = server.takeRequest()
+
+            assertEquals(HttpStatusCode.OK, response.status)
+            assertEquals("Successfully synced.", body["message"].asText())
+            assertTrue(body["modified"].asBoolean())
+            assertEquals("/fn/register?deployId=deploy-1", recordedRequest.path)
+            assertEquals("cloud", recordedRequest.getHeader(InngestHeaderKey.ExpectedServerKind.value))
+            assertEquals("2", recordedRequest.getHeader(InngestHeaderKey.RequestVersion.value))
+        }
+
+    @Test
+    fun `put route returns sync failure payload when register fails`() =
+        testApplication {
+            val server = MockWebServer()
+            mockWebServer = server
+            server.enqueue(MockResponse().setResponseCode(400).setBody("""{"error":"invalid config"}"""))
+
+            val apiBaseUrl = server.url("").toString().removeSuffix("/")
+
+            application {
+                routing {
+                    serve(
+                        path = "/api/inngest",
+                        client = Inngest("test-app", eventKey = "evt-key", isDev = true),
+                        fnList = listOf(EchoFunction()),
+                        baseUrl = apiBaseUrl,
+                    )
+                }
+            }
+
+            val response = client.put("/api/inngest")
+            val body = mapper.readTree(response.bodyAsText())
+
+            assertEquals(HttpStatusCode.InternalServerError, response.status)
+            assertEquals("invalid config", body["message"].asText())
+            assertEquals(false, body["modified"].asBoolean())
+        }
+
+    private class EchoFunction : InngestFunction() {
+        override fun config(builder: InngestFunctionConfigBuilder): InngestFunctionConfigBuilder = builder.id("echo-fn")
+
+        override fun execute(
+            ctx: FunctionContext,
+            step: Step,
+        ): Any = "done"
+    }
+}

--- a/inngest/src/test/resources/protocol/steps/invoke-step.json
+++ b/inngest/src/test/resources/protocol/steps/invoke-step.json
@@ -1,0 +1,15 @@
+{
+  "id": "bc850242362ed6d68bea1403ff2dcc40d5483657",
+  "name": "invoke-user",
+  "op": "InvokeFunction",
+  "statusCode": "StepComplete",
+  "opts": {
+    "function_id": "target-app-target-fn",
+    "payload": {
+      "data": {
+        "userId": "123"
+      }
+    },
+    "timeout": "30s"
+  }
+}

--- a/inngest/src/test/resources/protocol/steps/run-step.json
+++ b/inngest/src/test/resources/protocol/steps/run-step.json
@@ -1,0 +1,8 @@
+{
+  "id": "24989d8ee41c1575924630844ad094b55e6b1445",
+  "name": "compute",
+  "op": "StepRun",
+  "statusCode": "StepComplete",
+  "data": 42,
+  "error": null
+}

--- a/inngest/src/test/resources/protocol/steps/send-event-step.json
+++ b/inngest/src/test/resources/protocol/steps/send-event-step.json
@@ -1,0 +1,12 @@
+{
+  "id": "229b582fd9c3c15b1eb37497ad06bc933db37306",
+  "name": "send-user",
+  "op": "Step",
+  "statusCode": "StepComplete",
+  "data": {
+    "event_ids": [
+      "evt-1"
+    ]
+  },
+  "error": null
+}

--- a/inngest/src/test/resources/protocol/steps/sleep-step.json
+++ b/inngest/src/test/resources/protocol/steps/sleep-step.json
@@ -1,0 +1,9 @@
+{
+  "id": "ef8d29955a725c39916a4626f3921a0104242439",
+  "name": "pause",
+  "op": "Sleep",
+  "statusCode": "StepComplete",
+  "opts": {
+    "duration": "9s"
+  }
+}

--- a/inngest/src/test/resources/protocol/steps/wait-for-event-step.json
+++ b/inngest/src/test/resources/protocol/steps/wait-for-event-step.json
@@ -1,0 +1,11 @@
+{
+  "id": "6ec8f90b43a653be0aa3c340fbbf82e2849632cc",
+  "name": "wait-for-user",
+  "op": "WaitForEvent",
+  "statusCode": "StepComplete",
+  "opts": {
+    "event": "app/user.updated",
+    "timeout": "10m",
+    "if": "event.data.userId == async.data.userId"
+  }
+}

--- a/inngest/src/testFixtures/java/com/inngest/testing/ProtocolFixtures.java
+++ b/inngest/src/testFixtures/java/com/inngest/testing/ProtocolFixtures.java
@@ -1,0 +1,96 @@
+package com.inngest.testing;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.inngest.Event;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class ProtocolFixtures {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ProtocolFixtures() {
+    }
+
+    public static Event event(String name) {
+        return event(name, linkedData("message", "hello"));
+    }
+
+    public static Event event(String name, LinkedHashMap<String, Object> data) {
+        return new Event("evt-test", name, data, null, 1700000000000L, null);
+    }
+
+    public static LinkedHashMap<String, Object> linkedData(Object... keyValues) {
+        LinkedHashMap<String, Object> data = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            data.put((String) keyValues[i], keyValues[i + 1]);
+        }
+        return data;
+    }
+
+    public static Map<String, Object> memoizedData(Object data) {
+        return Collections.<String, Object>singletonMap("data", data);
+    }
+
+    public static Map<String, Object> memoizedError(String name, String message) {
+        LinkedHashMap<String, Object> error = new LinkedHashMap<>();
+        error.put("name", name);
+        error.put("message", message);
+        error.put("stack", name + ": " + message);
+
+        return Collections.<String, Object>singletonMap("error", error);
+    }
+
+    public static String executionRequestPayloadJson(String functionId) {
+        Event event = event("test/run");
+        return executionRequestPayloadJson(functionId, event, Collections.singletonList(event), Collections.emptyMap());
+    }
+
+    public static String executionRequestPayloadJson(
+        String functionId,
+        Event event,
+        List<Event> events,
+        Map<String, Object> steps
+    ) {
+        LinkedHashMap<String, Object> payload = new LinkedHashMap<>();
+        payload.put("ctx", executionContext(functionId));
+        payload.put("event", event);
+        payload.put("events", events);
+        payload.put("steps", steps);
+
+        try {
+            return MAPPER.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("failed to serialize execution payload", e);
+        }
+    }
+
+    public static String hashStepId(String stepId) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-1");
+            byte[] hashedBytes = digest.digest(stepId.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder();
+            for (byte hashedByte : hashedBytes) {
+                builder.append(String.format("%02x", hashedByte));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("SHA-1 not available", e);
+        }
+    }
+
+    private static Map<String, Object> executionContext(String functionId) {
+        LinkedHashMap<String, Object> ctx = new LinkedHashMap<>();
+        ctx.put("attempt", 0);
+        ctx.put("fn_id", functionId);
+        ctx.put("run_id", "run-test");
+        ctx.put("env", "test");
+        return ctx;
+    }
+}


### PR DESCRIPTION
## Summary

Implements the remaining work in plan `000` to lock the current SDK contract with tests and fixtures before deeper protocol refactors land.

This PR:
- adds shared protocol fixtures plus focused `CommHandler` contract tests for call success, retriable/non-retriable errors, required headers, and step payloads
- adds Ktor and Spring adapter route tests for `POST /api/inngest` and `PUT /api/inngest`
- normalizes sync success/failure handling so both adapters expose the same response shape and expected-server-kind forwarding
- adds golden JSON fixtures for step payload wire shapes
- documents intentionally unsupported protocol areas with skipped tests
- updates `docs/plans/000-lock-contract-with-tests.org` to `Done`
- fixes the current `make lint` failures in touched Kotlin files

## Verification

- `make lint`
- `nix develop -c ./gradlew :inngest:test :inngest-spring-boot-adapter:test :inngest-spring-boot-demo:test`
- `./scripts/check-plan-status.sh`

## Notes

Documented unsupported areas that remain for later plans:
- in-band sync
- `waitForEvent` `match` convenience API
- `StepPlanned` / `StepNotFound` opcode flow

## Related

- `docs/plans/000-lock-contract-with-tests.org`
