### PR TITLE
fix(protocol): align base protocol correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 [Inngest](https://www.inngest.com) SDK for Kotlin with Java interoperability.
 
+This SDK tracks the canonical [Inngest SDK specification](https://github.com/inngest/inngest/blob/main/docs/SDK_SPEC.md).
+
 ## Defining a function
 
 <details open>

--- a/docs/plans/001-fix-base-protocol-correctness.org
+++ b/docs/plans/001-fix-base-protocol-correctness.org
@@ -1,34 +1,34 @@
 #+title: 001 Fix Base Protocol Correctness
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Active
+#+STATUS: Done
 
 * Goal
-- [ ] Bring the baseline HTTP protocol into compliance before adding new execution features.
-- [ ] Remove correctness and security gaps that affect every request.
+- [X] Bring the baseline HTTP protocol into compliance before adding new execution features.
+- [X] Remove correctness and security gaps that affect every request.
 
 * Scope
-- [ ] Required headers and SDK identity.
+- [X] Required headers and SDK identity.
 - [X] Signature verification parity across adapters.
 - [X] Sync request and sync response semantics.
-- [ ] Composite function identifiers and runtime metadata.
+- [X] Composite function identifiers and runtime metadata.
 
 * Checklist
 - [X] Add =X-Inngest-Req-Version: 2= to call responses and outbound SDK-to-Inngest requests.
-- [ ] Ensure the sync payload =sdk= value matches the =X-Inngest-Sdk= header value.
+- [X] Ensure the sync payload =sdk= value matches the =X-Inngest-Sdk= header value.
 - [X] Fix Ktor call handling to validate =X-Inngest-Signature= before execution.
-- [ ] Normalize Spring and Ktor error handling so protocol failures return the intended status and body shape.
+- [X] Normalize Spring and Ktor error handling so protocol failures return the intended status and body shape.
 - [X] Return spec-shaped sync responses with =message= and =modified= fields.
 - [X] Parse Inngest sync success/failure responses and map them to local sync responses.
 - [X] Forward =X-Inngest-Expected-Server-Kind= during sync when present on the incoming request.
-- [ ] Ensure function runtime URLs use the composite function ID in =fnId=.
-- [ ] Fix sync runtime metadata so HTTP runtime =type= is =http= rather than the URL scheme.
-- [ ] Add or update tests for all corrected protocol fields.
+- [X] Ensure function runtime URLs use the composite function ID in =fnId=.
+- [X] Fix sync runtime metadata so HTTP runtime =type= is =http= rather than the URL scheme.
+- [X] Add or update tests for all corrected protocol fields.
 
 * Exit Criteria
-- [ ] Both adapters enforce request verification for call requests.
-- [ ] Sync payloads and sync responses match the intended protocol shape.
-- [ ] Required headers are consistently present on responses and outbound requests.
+- [X] Both adapters enforce request verification for call requests.
+- [X] Sync payloads and sync responses match the intended protocol shape.
+- [X] Required headers are consistently present on responses and outbound requests.
 
 * Current Notes
 - [X] Spring and Ktor call responses include =X-Inngest-Req-Version: 2= via shared SDK headers.
@@ -36,6 +36,6 @@
 - [X] Ktor and Spring both validate =X-Inngest-Signature= before call execution.
 - [X] Sync responses now map upstream success and failure bodies into local =message= and =modified= fields.
 - [X] Sync forwards incoming =X-Inngest-Server-Kind= as =X-Inngest-Expected-Server-Kind=.
-- [ ] Sync registration payload still reports =sdk= as =java:v...= while headers report =inngest-kt:v...=.
-- [ ] Runtime metadata still derives =type= from URL scheme and uses the local function ID in =fnId=.
-- [ ] Adapter protocol failures still need normalized status/body handling instead of plain exception strings.
+- [X] Sync registration payload now reports the same =sdk= value as =X-Inngest-Sdk=.
+- [X] Runtime metadata now uses =type= =http= and the composite function ID in =fnId=.
+- [X] Adapter protocol failures now return normalized JSON error bodies instead of plain exception strings.

--- a/docs/plans/001-fix-base-protocol-correctness.org
+++ b/docs/plans/001-fix-base-protocol-correctness.org
@@ -1,7 +1,7 @@
 #+title: 001 Fix Base Protocol Correctness
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Draft
+#+STATUS: Active
 
 * Goal
 - [ ] Bring the baseline HTTP protocol into compliance before adding new execution features.
@@ -9,18 +9,18 @@
 
 * Scope
 - [ ] Required headers and SDK identity.
-- [ ] Signature verification parity across adapters.
-- [ ] Sync request and sync response semantics.
+- [X] Signature verification parity across adapters.
+- [X] Sync request and sync response semantics.
 - [ ] Composite function identifiers and runtime metadata.
 
 * Checklist
-- [ ] Add =X-Inngest-Req-Version: 2= to call responses and outbound SDK-to-Inngest requests.
+- [X] Add =X-Inngest-Req-Version: 2= to call responses and outbound SDK-to-Inngest requests.
 - [ ] Ensure the sync payload =sdk= value matches the =X-Inngest-Sdk= header value.
-- [ ] Fix Ktor call handling to validate =X-Inngest-Signature= before execution.
+- [X] Fix Ktor call handling to validate =X-Inngest-Signature= before execution.
 - [ ] Normalize Spring and Ktor error handling so protocol failures return the intended status and body shape.
-- [ ] Return spec-shaped sync responses with =message= and =modified= fields.
-- [ ] Parse Inngest sync success/failure responses and map them to local sync responses.
-- [ ] Forward =X-Inngest-Expected-Server-Kind= during sync when present on the incoming request.
+- [X] Return spec-shaped sync responses with =message= and =modified= fields.
+- [X] Parse Inngest sync success/failure responses and map them to local sync responses.
+- [X] Forward =X-Inngest-Expected-Server-Kind= during sync when present on the incoming request.
 - [ ] Ensure function runtime URLs use the composite function ID in =fnId=.
 - [ ] Fix sync runtime metadata so HTTP runtime =type= is =http= rather than the URL scheme.
 - [ ] Add or update tests for all corrected protocol fields.
@@ -29,3 +29,13 @@
 - [ ] Both adapters enforce request verification for call requests.
 - [ ] Sync payloads and sync responses match the intended protocol shape.
 - [ ] Required headers are consistently present on responses and outbound requests.
+
+* Current Notes
+- [X] Spring and Ktor call responses include =X-Inngest-Req-Version: 2= via shared SDK headers.
+- [X] Outbound SDK requests include =X-Inngest-Req-Version: 2= via the shared =Inngest= HTTP client headers.
+- [X] Ktor and Spring both validate =X-Inngest-Signature= before call execution.
+- [X] Sync responses now map upstream success and failure bodies into local =message= and =modified= fields.
+- [X] Sync forwards incoming =X-Inngest-Server-Kind= as =X-Inngest-Expected-Server-Kind=.
+- [ ] Sync registration payload still reports =sdk= as =java:v...= while headers report =inngest-kt:v...=.
+- [ ] Runtime metadata still derives =type= from URL scheme and uses the local function ID in =fnId=.
+- [ ] Adapter protocol failures still need normalized status/body handling instead of plain exception strings.

--- a/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
+++ b/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
@@ -9,7 +9,6 @@ import com.inngest.signingkey.SignatureVerificationKt;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -67,22 +66,29 @@ public abstract class InngestController {
     public ResponseEntity<String> handleRequest(
         @RequestHeader(name = "X-Inngest-Signature", required = false) String signature,
         @RequestHeader(name = "X-Inngest-Server-Kind", required = false) String serverKind,
-        @RequestParam(name = "fnId") String functionId,
+        @RequestParam(name = "fnId", required = false) String functionId,
         @RequestBody String body
     ) {
         try {
+            if (functionId == null) {
+                return commResponse(commHandler.protocolErrorResponse(new IllegalArgumentException("Missing fnId parameter")));
+            }
+
             SignatureVerificationKt.checkHeadersAndValidateSignature(signature, body, serverKind, commHandler.getConfig());
 
             CommResponse response = commHandler.callFunction(functionId, body);
 
-            HttpHeaders headers = new HttpHeaders();
-            response.getHeaders().forEach(headers::add);
-
-            return ResponseEntity.status(response.getStatusCode().getCode()).headers(headers)
-                .body(response.getBody());
+            return commResponse(response);
         } catch (Exception e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(e.toString());
+            return commResponse(commHandler.protocolErrorResponse(e));
         }
+    }
+
+    private ResponseEntity<String> commResponse(CommResponse response) {
+        HttpHeaders headers = new HttpHeaders();
+        response.getHeaders().forEach(headers::add);
+
+        return ResponseEntity.status(response.getStatusCode().getCode()).headers(headers)
+            .body(response.getBody());
     }
 }

--- a/inngest-spring-boot-adapter/src/test/java/com/inngest/springboot/InngestControllerTest.java
+++ b/inngest-spring-boot-adapter/src/test/java/com/inngest/springboot/InngestControllerTest.java
@@ -46,9 +46,18 @@ public class InngestControllerTest {
 
     @BeforeEach
     void setUp() {
+        setUpController(true, null);
+    }
+
+    private void setUpController(boolean isDev, String signingKey) {
         TestController controller = new TestController();
-        Inngest client = new Inngest("test-app", null, "evt-key", null, true);
-        controller.commHandler = new CommHandler(FUNCTIONS, client, new ServeConfig(client), SupportedFrameworkName.SpringBoot);
+        Inngest client = new Inngest("test-app", null, "evt-key", null, isDev);
+        controller.commHandler = new CommHandler(
+            FUNCTIONS,
+            client,
+            new ServeConfig(client, null, signingKey, null, null, null, null),
+            SupportedFrameworkName.SpringBoot
+        );
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
     }
 
@@ -75,6 +84,27 @@ public class InngestControllerTest {
             .getContentAsString();
 
         assertEquals("\"done\"", responseBody);
+    }
+
+    @Test
+    void postRouteReturnsJsonProtocolFailureWhenSignatureIsMissingInCloud() throws Exception {
+        setUpController(false, "signkey-test-12345678");
+
+        String responseBody = mockMvc.perform(post("/api/inngest")
+                .queryParam("fnId", "echo-fn")
+                .header(InngestHeaderKey.ServerKind.getValue(), "cloud")
+                .contentType("application/json")
+                .content(ProtocolFixtures.executionRequestPayloadJson("echo-fn")))
+            .andExpect(status().isInternalServerError())
+            .andExpect(header().string(InngestHeaderKey.RequestVersion.getValue(), "2"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        JsonNode body = MAPPER.readTree(responseBody);
+
+        assertEquals("Using cloud inngest but did not receive X-Inngest-Signature", body.get("message").asText());
+        assertTrue(body.get("__serialized").asBoolean());
     }
 
     @Test

--- a/inngest-spring-boot-adapter/src/test/java/com/inngest/springboot/InngestControllerTest.java
+++ b/inngest-spring-boot-adapter/src/test/java/com/inngest/springboot/InngestControllerTest.java
@@ -99,12 +99,19 @@ public class InngestControllerTest {
 
         JsonNode body = MAPPER.readTree(responseBody);
         RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        JsonNode requestBody = MAPPER.readTree(recordedRequest.getBody().readUtf8());
+        JsonNode function = requestBody.get("functions").get(0);
+        JsonNode runtime = function.get("steps").get("step").get("runtime");
 
         assertEquals("Successfully synced.", body.get("message").asText());
         assertTrue(body.get("modified").asBoolean());
         assertEquals("/fn/register?deployId=deploy-1", recordedRequest.getPath());
         assertEquals("cloud", recordedRequest.getHeader(InngestHeaderKey.ExpectedServerKind.getValue()));
         assertEquals("2", recordedRequest.getHeader(InngestHeaderKey.RequestVersion.getValue()));
+        assertEquals(recordedRequest.getHeader(InngestHeaderKey.Sdk.getValue()), requestBody.get("sdk").asText());
+        assertEquals("test-app-echo-fn", function.get("id").asText());
+        assertEquals("http", runtime.get("type").asText());
+        assertEquals(requestBody.get("url").asText() + "?fnId=test-app-echo-fn&stepId=step", runtime.get("url").asText());
     }
 
     @Test

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/ImageFromPrompt.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/ImageFromPrompt.kt
@@ -17,7 +17,9 @@ class ImageFromPrompt : InngestFunction() {
             try {
                 step.run("generate-image-dall-e") {
                     // Call the DALL-E model to generate an image
-                    throw Exception("Failed to generate image")
+                    if (ctx.event.data["forceFallback"] == true) {
+                        throw StepError("Failed to generate image")
+                    }
 
                     "example.com/image-dall-e.jpg"
                 }

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/PushToSlackChannel.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/PushToSlackChannel.kt
@@ -15,7 +15,9 @@ class PushToSlackChannel : InngestFunction() {
     ): String =
         step.run("push-to-slack-channel") {
             // Call Slack API to push the image to a channel
-            throw NonRetriableError("Failed to push image to Slack channel ${ctx.event.data["image"]}")
+            if (ctx.event.data["forceFail"] == true) {
+                throw NonRetriableError("Failed to push image to Slack channel ${ctx.event.data["image"]}")
+            }
 
             "Image pushed to Slack channel"
         }

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/SlackFailureReport.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/SlackFailureReport.kt
@@ -13,9 +13,12 @@ class SlackFailureReport : InngestFunction() {
         ctx: FunctionContext,
         step: Step,
     ): String {
-        step.run("throw exception") {
-            throw RuntimeException("This function always fails")
-            "Step result"
+        step.run<String>("throw exception") {
+            if (ctx.event.data["forceSuccess"] == true) {
+                "Step result"
+            } else {
+                throw RuntimeException("This function always fails")
+            }
         }
 
         return "Success"

--- a/inngest-test-server/src/main/kotlin/com/inngest/testserver/TranscodeVideo.kt
+++ b/inngest-test-server/src/main/kotlin/com/inngest/testserver/TranscodeVideo.kt
@@ -30,11 +30,13 @@ class TranscodeVideo : InngestFunction() {
                 "Hi there, My name is Jamie..." // dummy example content
             }
 
-        step.run("save-results") {
-            // Save summary, to your database
-            // database.save(event.data["videoId"], transcription, summary)
-        }
+        val saved =
+            step.run("save-results") {
+                // Save summary, to your database
+                // database.save(event.data["videoId"], transcription, summary)
+                mapOf("transcription" to transcription, "summary" to summary)
+            }
 
-        return hashMapOf("restored" to false)
+        return hashMapOf("restored" to false, "transcription" to transcription, "summary" to summary, "saved" to saved)
     }
 }

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -71,6 +71,23 @@ private fun generateFailureFunctions(
             fn.toFailureHandler(client.appId)?.let { it.id()!! to it }
         }.toMap()
 
+private fun compositeFunctionId(
+    appId: String,
+    functionId: String,
+): String = "$appId-$functionId"
+
+private fun indexFunctions(
+    functions: Map<String, InternalInngestFunction>,
+    appId: String,
+): Map<String, InternalInngestFunction> =
+    functions
+        .flatMap { (functionId, function) ->
+            listOf(
+                functionId to function,
+                compositeFunctionId(appId, functionId) to function,
+            )
+        }.toMap()
+
 class CommHandler(
     functions: Map<String, InngestFunction>,
     val client: Inngest,
@@ -79,8 +96,10 @@ class CommHandler(
 ) {
     val headers = Environment.inngestHeaders(framework).plus(client.headers)
 
+    private val baseFunctions = functions.mapValues { (_, fn) -> fn.toInngestFunction() }
     private val failureFunctions = generateFailureFunctions(functions, client)
-    private val functions = functions.mapValues { (_, fn) -> fn.toInngestFunction() }.plus(failureFunctions)
+    private val allFunctions = baseFunctions.plus(failureFunctions)
+    private val functionsById = indexFunctions(allFunctions, client.appId)
 
     fun callFunction(
         functionId: String,
@@ -89,7 +108,7 @@ class CommHandler(
         try {
             val payload = Klaxon().parse<ExecutionRequestPayload>(requestBody)
             // TODO - check that payload is not null and throw error
-            val function = functions[functionId] ?: throw Exception("Function not found")
+            val function = functionsById[functionId] ?: throw Exception("Function not found")
 
             val ctx =
                 FunctionContext(
@@ -153,7 +172,7 @@ class CommHandler(
 
     private fun getFunctionConfigs(origin: String): List<InternalFunctionConfig> {
         val configs: MutableList<InternalFunctionConfig> = mutableListOf()
-        functions.forEach { entry -> configs.add(entry.value.getFunctionConfig(getServeUrl(origin), client)) }
+        allFunctions.forEach { entry -> configs.add(entry.value.getFunctionConfig(getServeUrl(origin), client)) }
         return configs
     }
 
@@ -222,7 +241,7 @@ class CommHandler(
     ): String {
         val insecureIntrospection =
             InsecureIntrospection(
-                functionCount = functions.size,
+                functionCount = allFunctions.size,
                 hasEventKey = Environment.isInngestEventKeySet(client.eventKey),
                 hasSigningKey = config.hasSigningKey(),
                 mode = if (client.env == InngestEnv.Dev) "dev" else "cloud",
@@ -239,7 +258,7 @@ class CommHandler(
                         checkHeadersAndValidateSignature(signature, requestBody, serverKind, config)
 
                         SecureIntrospection(
-                            functionCount = functions.size,
+                            functionCount = allFunctions.size,
                             hasEventKey = Environment.isInngestEventKeySet(client.eventKey),
                             hasSigningKey = config.hasSigningKey(),
                             authenticationSucceeded = true,
@@ -269,7 +288,7 @@ class CommHandler(
         RegistrationRequestPayload(
             appName = config.appId(),
             framework = framework.value,
-            sdk = "java:v${Version.getVersion()}",
+            sdk = Environment.inngestSdk(),
             url = getServeUrl(origin),
             v = "0.1",
             functions = getFunctionConfigs(origin),

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -137,25 +137,33 @@ class CommHandler(
             val statusCode =
                 if (retryDecision.shouldRetry) ResultStatusCode.RetriableError else ResultStatusCode.NonRetriableError
 
-            val err =
-                CommError(
-                    name = e.toString(),
-                    message = e.message,
-                    stack = e.stackTrace.joinToString(separator = "\n"),
-                )
             return CommResponse(
-                body = parseRequestBody(err),
+                body = parseRequestBody(commError(e)),
                 statusCode = statusCode,
                 headers = headers.plus(retryDecision.headers),
             )
         }
     }
 
+    fun protocolErrorResponse(e: Throwable): CommResponse =
+        CommResponse(
+            body = parseRequestBody(commError(e)),
+            statusCode = ResultStatusCode.RetriableError,
+            headers = headers,
+        )
+
     private fun parseRequestBody(requestBody: Any?): String {
         val mapper = ObjectMapper()
         mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
         return mapper.writeValueAsString(requestBody)
     }
+
+    private fun commError(e: Throwable): CommError =
+        CommError(
+            name = e.toString(),
+            message = e.message,
+            stack = e.stackTrace.joinToString(separator = "\n"),
+        )
 
     private fun serializePayload(payload: Any?): String {
         try {

--- a/inngest/src/main/kotlin/com/inngest/Environment.kt
+++ b/inngest/src/main/kotlin/com/inngest/Environment.kt
@@ -3,8 +3,10 @@ package com.inngest
 object Environment {
     private fun systemValue(key: String): String? = System.getProperty(key) ?: System.getenv(key)
 
+    fun inngestSdk(): String = "inngest-kt:${Version.getVersion()}"
+
     fun inngestHeaders(framework: SupportedFrameworkName? = null): RequestHeaders {
-        val sdk = "inngest-kt:${Version.getVersion()}"
+        val sdk = inngestSdk()
         return mapOf(
             InngestHeaderKey.ContentType.value to "application/json",
             InngestHeaderKey.Sdk.value to sdk,

--- a/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
+++ b/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
@@ -292,8 +292,10 @@ class InngestFunctionConfigBuilder {
      */
     fun idempotency(idempotencyKey: String): InngestFunctionConfigBuilder = apply { this.idempotency = idempotencyKey }
 
-    private fun buildSteps(serveUrl: String): Map<String, StepConfig> {
-        val scheme = serveUrl.split("://")[0]
+    private fun buildSteps(
+        serveUrl: String,
+        functionId: String,
+    ): Map<String, StepConfig> {
         return mapOf(
             "step" to
                 StepConfig(
@@ -302,8 +304,8 @@ class InngestFunctionConfigBuilder {
                     retries = mapOf("attempts" to this.retries),
                     runtime =
                         hashMapOf(
-                            "type" to scheme,
-                            "url" to "$serveUrl?fnId=$id&stepId=step",
+                            "type" to "http",
+                            "url" to "$serveUrl?fnId=$functionId&stepId=step",
                         ),
                 ),
         )
@@ -330,7 +332,7 @@ class InngestFunctionConfigBuilder {
                 idempotency,
                 cancel,
                 batchEvents,
-                steps = buildSteps(serverUrl),
+                steps = buildSteps(serverUrl, globalId),
             )
         return config
     }

--- a/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
+++ b/inngest/src/main/kotlin/com/inngest/InngestFunctionConfigBuilder.kt
@@ -295,8 +295,8 @@ class InngestFunctionConfigBuilder {
     private fun buildSteps(
         serveUrl: String,
         functionId: String,
-    ): Map<String, StepConfig> {
-        return mapOf(
+    ): Map<String, StepConfig> =
+        mapOf(
             "step" to
                 StepConfig(
                     id = "step",
@@ -309,7 +309,6 @@ class InngestFunctionConfigBuilder {
                         ),
                 ),
         )
-    }
 
     internal fun build(
         appId: String,

--- a/inngest/src/main/kotlin/com/inngest/ktor/Route.kt
+++ b/inngest/src/main/kotlin/com/inngest/ktor/Route.kt
@@ -56,7 +56,8 @@ fun Route.serve(
         post("") {
             val fnId = call.request.queryParameters["fnId"]
             if (fnId == null) {
-                call.respond(HttpStatusCode.BadRequest, "Missing fnId parameter")
+                val response = comm.protocolErrorResponse(IllegalArgumentException("Missing fnId parameter"))
+                call.respondComm(response)
             } else {
                 val body = call.receiveText()
                 try {
@@ -65,13 +66,10 @@ fun Route.serve(
                     checkHeadersAndValidateSignature(signature, body, serverKind, comm.config)
 
                     val response = comm.callFunction(fnId, body)
-                    response.headers.forEach({ (k, v) -> call.response.header(k, v) })
-                    call.response.status(
-                        HttpStatusCode(response.statusCode.code, response.statusCode.message),
-                    )
-                    call.respondText(response.body)
+                    call.respondComm(response)
                 } catch (e: Exception) {
-                    call.respond(HttpStatusCode.InternalServerError, e.toString())
+                    val response = comm.protocolErrorResponse(e)
+                    call.respondComm(response)
                 }
             }
         }
@@ -86,6 +84,15 @@ fun Route.serve(
             call.respondText(response.body, ContentType.Application.Json, HttpStatusCode.fromValue(response.statusCode))
         }
     }
+}
+
+private suspend fun ApplicationCall.respondComm(response: CommResponse) {
+    response.headers.forEach { (k, v) -> this.response.header(k, v) }
+    respondText(
+        response.body,
+        ContentType.Application.Json,
+        HttpStatusCode(response.statusCode.code, response.statusCode.message),
+    )
 }
 
 val HTTP_PORTS = listOf(80, 443)

--- a/inngest/src/main/kotlin/com/inngest/signingkey/SignatureVerification.kt
+++ b/inngest/src/main/kotlin/com/inngest/signingkey/SignatureVerification.kt
@@ -41,9 +41,9 @@ private fun signRequest(
 
 class InvalidSignatureHeaderException(
     message: String,
-) : Throwable(message)
+) : Exception(message)
 
-class ExpiredSignatureHeaderException : Throwable("signature header has expired")
+class ExpiredSignatureHeaderException : Exception("signature header has expired")
 
 const val FIVE_MINUTES_IN_SECONDS = 5L * 60
 

--- a/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
@@ -35,6 +35,16 @@ internal class CommHandlerTest {
     }
 
     @Test
+    fun `callFunction accepts composite function ids`() {
+        val response =
+            commHandler(EchoFunction())
+                .callFunction("test-app-echo-fn", ProtocolFixtures.executionRequestPayloadJson("echo-fn"))
+
+        assertEquals(ResultStatusCode.FunctionComplete, response.statusCode)
+        assertEquals("done", mapper.readValue(response.body, String::class.java))
+    }
+
+    @Test
     fun `callFunction marks non-retriable errors correctly`() {
         val response =
             commHandler(NonRetriableFailureFunction())

--- a/inngest/src/test/kotlin/com/inngest/InngestFunctionConfigBuilderTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/InngestFunctionConfigBuilderTest.kt
@@ -17,6 +17,19 @@ class InngestFunctionConfigBuilderTest {
     }
 
     @Test
+    fun testStepRuntimeUsesHttpAndCompositeFunctionId() {
+        val config =
+            InngestFunctionConfigBuilder()
+                .id("test-id")
+                .build("app-id", "https://mysite.com/api/inngest")
+
+        val runtime = config.steps["step"]!!.runtime
+
+        assertEquals("http", runtime["type"])
+        assertEquals("https://mysite.com/api/inngest?fnId=app-id-test-id&stepId=step", runtime["url"])
+    }
+
+    @Test
     fun testMissingId() {
         assertFailsWith<InngestInvalidConfigurationException> {
             InngestFunctionConfigBuilder()

--- a/inngest/src/test/kotlin/com/inngest/ktor/RouteTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/ktor/RouteTest.kt
@@ -83,6 +83,9 @@ internal class RouteTest {
 
             val body = mapper.readTree(response.bodyAsText())
             val recordedRequest = server.takeRequest()
+            val requestBody = mapper.readTree(recordedRequest.body.readUtf8())
+            val function = requestBody["functions"][0]
+            val runtime = function["steps"]["step"]["runtime"]
 
             assertEquals(HttpStatusCode.OK, response.status)
             assertEquals("Successfully synced.", body["message"].asText())
@@ -90,6 +93,10 @@ internal class RouteTest {
             assertEquals("/fn/register?deployId=deploy-1", recordedRequest.path)
             assertEquals("cloud", recordedRequest.getHeader(InngestHeaderKey.ExpectedServerKind.value))
             assertEquals("2", recordedRequest.getHeader(InngestHeaderKey.RequestVersion.value))
+            assertEquals(recordedRequest.getHeader(InngestHeaderKey.Sdk.value), requestBody["sdk"].asText())
+            assertEquals("test-app-echo-fn", function["id"].asText())
+            assertEquals("http", runtime["type"].asText())
+            assertEquals("${requestBody["url"].asText()}?fnId=test-app-echo-fn&stepId=step", runtime["url"].asText())
         }
 
     @Test

--- a/inngest/src/test/kotlin/com/inngest/ktor/RouteTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/ktor/RouteTest.kt
@@ -57,6 +57,35 @@ internal class RouteTest {
         }
 
     @Test
+    fun `post route returns JSON protocol failure when signature is missing in cloud`() =
+        testApplication {
+            application {
+                routing {
+                    serve(
+                        "/api/inngest",
+                        Inngest("test-app", eventKey = "evt-key", isDev = false),
+                        listOf(EchoFunction()),
+                        signingKey = "signkey-test-12345678",
+                    )
+                }
+            }
+
+            val response =
+                client.post("/api/inngest?fnId=echo-fn") {
+                    header(InngestHeaderKey.ServerKind.value, "cloud")
+                    contentType(ContentType.Application.Json)
+                    setBody(ProtocolFixtures.executionRequestPayloadJson("echo-fn"))
+                }
+
+            val body = mapper.readTree(response.bodyAsText())
+
+            assertEquals(HttpStatusCode.InternalServerError, response.status)
+            assertEquals("2", response.headers[InngestHeaderKey.RequestVersion.value])
+            assertEquals("Using cloud inngest but did not receive X-Inngest-Signature", body["message"].asText())
+            assertTrue(body["__serialized"].asBoolean())
+        }
+
+    @Test
     fun `put route returns successful sync response and forwards expected server kind`() =
         testApplication {
             val server = MockWebServer()


### PR DESCRIPTION
## Summary
- align sync registration SDK identity and runtime metadata with the SDK spec
- accept composite function IDs for calls while preserving local IDs
- normalize Spring and Ktor protocol failure responses as JSON
- mark plan 001 complete and link the canonical SDK spec

## Tests
- ./gradlew test
- scripts/check-plan-status.sh