### PR TITLE
fix: cloud event deserialization

### DIFF
--- a/inngest/src/main/kotlin/com/inngest/Event.kt
+++ b/inngest/src/main/kotlin/com/inngest/Event.kt
@@ -1,11 +1,11 @@
 package com.inngest
 
 data class Event(
-    val id: String,
+    val id: String? = null,
     val name: String,
     val data: LinkedHashMap<String, Any>,
     val user: LinkedHashMap<String, Any>? = null,
-    val ts: Long,
+    val ts: Long? = null,
     val v: Any? = null,
 )
 

--- a/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
@@ -35,6 +35,43 @@ internal class CommHandlerTest {
     }
 
     @Test
+    fun `callFunction accepts event payload without optional id and timestamp`() {
+        val response =
+            commHandler(EchoFunction())
+                .callFunction(
+                    "echo-fn",
+                    """
+                    {
+                      "ctx": {
+                        "attempt": 0,
+                        "fn_id": "echo-fn",
+                        "run_id": "run-test",
+                        "env": "test"
+                      },
+                      "event": {
+                        "name": "test/run",
+                        "data": {
+                          "message": "hello"
+                        }
+                      },
+                      "events": [
+                        {
+                          "name": "test/run",
+                          "data": {
+                            "message": "hello"
+                          }
+                        }
+                      ],
+                      "steps": {}
+                    }
+                    """.trimIndent(),
+                )
+
+        assertEquals(ResultStatusCode.FunctionComplete, response.statusCode, response.body)
+        assertEquals("done", mapper.readValue(response.body, String::class.java))
+    }
+
+    @Test
     fun `callFunction accepts composite function ids`() {
         val response =
             commHandler(EchoFunction())


### PR DESCRIPTION
resolves #99 

## Summary

Fixes Cloud function execution payload deserialization when incoming events omit optional event metadata.

## Root Cause

`Event` required `id` and `ts`, but Inngest event payloads only require `name` and `data`. Cloud can send execution payloads where `event` and `events[]` do not include `id` or `ts`, which caused Klaxon to fail before the function handler ran.

## Changes

- Make execution `Event.id` and `Event.ts` nullable with defaults.
- Add a regression test for a function execution payload whose `event` and `events[]` omit optional `id` and `ts`.

## Validation

- `./gradlew :inngest:test`
- `./gradlew :inngest-spring-boot-adapter:test`
- `./gradlew test`
- `git diff --check`