### PR TITLE
ci: test spring boot and java compatibility matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,17 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ matrix.java }}
+          java-version: "21"
           java-package: jdk
           cache: gradle
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          java-package: jdk
 
       - name: Test
-        run: make test SPRING_BOOT_VERSION=${{ matrix.spring-boot }}
+        run: JAVA_HOME="${JAVA_HOME_21_X64}" PATH="${JAVA_HOME_21_X64}/bin:${PATH}" make test SPRING_BOOT_VERSION=${{ matrix.spring-boot }} TEST_JAVA_VERSION=${{ matrix.java }}
 
   lint:
     name: Lint
@@ -73,12 +78,17 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: ${{ matrix.java }}
+          java-version: "21"
           java-package: jdk
           cache: gradle
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.java }}
+          java-package: jdk
       - uses: DeterminateSystems/nix-installer-action@v22
       - name: Initialize Nix dev shell
         run: nix develop -c true
 
       - name: Test
-        run: nix develop -c make itest SPRING_BOOT_VERSION=${{ matrix.spring-boot }}
+        run: JAVA_HOME="${JAVA_HOME_21_X64}" PATH="${JAVA_HOME_21_X64}/bin:${PATH}" nix develop -c make itest SPRING_BOOT_VERSION=${{ matrix.spring-boot }} TEST_JAVA_VERSION=${{ matrix.java }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
             spring-boot: "3.5.14"
           - java: "11"
             spring-boot: "4.0.6"
+          - java: "25"
+            spring-boot: "2.7.18"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -73,6 +75,8 @@ jobs:
             spring-boot: "3.5.14"
           - java: "11"
             spring-boot: "4.0.6"
+          - java: "25"
+            spring-boot: "2.7.18"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
   itest:
     name: Integration Test (Java ${{ matrix.java }}, Spring Boot ${{ matrix.spring-boot }})
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-22.04-4
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,12 +8,22 @@ on:
 
 jobs:
   test:
-    name: Test (Java ${{ matrix.java }})
+    name: Test (Java ${{ matrix.java }}, Spring Boot ${{ matrix.spring-boot }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        java: ["8", "11", "17", "21"]
+        java: ["8", "11", "17", "21", "25"]
+        spring-boot: ["2.7.18", "3.5.14", "4.0.6"]
+        exclude:
+          - java: "8"
+            spring-boot: "3.5.14"
+          - java: "8"
+            spring-boot: "4.0.6"
+          - java: "11"
+            spring-boot: "3.5.14"
+          - java: "11"
+            spring-boot: "4.0.6"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -24,7 +34,7 @@ jobs:
           cache: gradle
 
       - name: Test
-        run: make test
+        run: make test SPRING_BOOT_VERSION=${{ matrix.spring-boot }}
 
   lint:
     name: Lint
@@ -42,12 +52,22 @@ jobs:
           reporter: github-pr-review
 
   itest:
-    name: Integration Test (Java ${{ matrix.java }})
+    name: Integration Test (Java ${{ matrix.java }}, Spring Boot ${{ matrix.spring-boot }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        java: ["8", "11", "17", "21"]
+        java: ["8", "11", "17", "21", "25"]
+        spring-boot: ["2.7.18", "3.5.14", "4.0.6"]
+        exclude:
+          - java: "8"
+            spring-boot: "3.5.14"
+          - java: "8"
+            spring-boot: "4.0.6"
+          - java: "11"
+            spring-boot: "3.5.14"
+          - java: "11"
+            spring-boot: "4.0.6"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -61,4 +81,4 @@ jobs:
         run: nix develop -c true
 
       - name: Test
-        run: nix develop -c make itest
+        run: nix develop -c make itest SPRING_BOOT_VERSION=${{ matrix.spring-boot }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,121 @@
+# Agent Guide
+
+This file provides guidance to AI coding agents working in this repository.
+
+## Repository Context
+
+This repository is the Inngest SDK for Kotlin with Java interoperability. It is
+a Gradle multi-project build with these modules:
+
+- `inngest` - core SDK package published as `com.inngest:inngest`.
+- `inngest-spring-boot-adapter` - Spring Boot adapter published as
+  `com.inngest:inngest-spring-boot-adapter`.
+- `inngest-test-server` - Ktor development/test server for exercising the SDK.
+- `inngest-spring-boot-demo` - Spring Boot demo and integration test app.
+
+Prefer local documentation and plans over broad assumptions. The canonical SDK
+contract is tracked in the upstream Inngest SDK specification linked from
+`README.md`, and active implementation plans live in `docs/plans/`. Use
+`scripts/check-plan-status.sh` to review plan status when working from a plan.
+
+## Commit and PR Titles
+
+Conventional Commit-style titles are required for any commit or PR title you
+create. This repository's changelog configuration in `cliff.toml` enables
+`conventional_commits = true` and `filter_unconventional = true`, so
+non-conventional titles are easy to lose or misclassify.
+
+Keep title types aligned with `cliff.toml` and `.github/workflows/commits.yml`.
+The accepted types are:
+
+- `feat`
+- `fix`
+- `doc`
+- `perf`
+- `refactor`
+- `style`
+- `test`
+- `chore`
+- `ci`
+- `revert`
+- `security`
+
+Use standard conventional formatting such as
+`fix(inngest): preserve retry-after headers` or
+`test(spring-boot): cover introspection signatures`.
+
+## Pull Request Text
+
+When preparing PR text, follow `.github/pull_request_template.md`:
+
+- `Summary` should briefly explain what changed and why.
+- `Changes` should list notable implementation details when helpful.
+- `Checklist` should mark documentation and test coverage as complete or
+  explicitly not applicable.
+- `Related` should include linked issues or PRs when present.
+
+Do not add a second PR-note convention unless release automation is changed to
+expect it.
+
+## Release Metadata
+
+Releases are package-prefixed. The releasable packages keep their versions in:
+
+- `inngest/VERSION`
+- `inngest-spring-boot-adapter/VERSION`
+
+Release tags use package-prefixed names such as `inngest-0.2.2` and
+`inngest-spring-boot-adapter-0.2.1`. Release automation and package changelog
+generation are implemented by the scripts in `scripts/` and the GitHub
+workflows in `.github/workflows/`.
+
+## Development Commands
+
+- `make dev-ktor` runs the Ktor test server via
+  `./gradlew inngest-test-server:run`.
+- `make dev-spring-boot` runs the Spring Boot demo with
+  `SPRING_BOOT_VERSION` defaulting to `2.7.18`.
+- `make inngest-dev` starts the local Inngest dev server pointed at
+  `http://127.0.0.1:8080/api/inngest`.
+- `make test` runs the core, Ktor, Spring adapter, and Spring demo tests.
+- `make itest` runs Spring demo integration tests.
+- `make test-core` runs tests for `inngest`.
+- `make test-ktor` runs tests for `inngest-test-server`.
+- `make test-springboot-adapter` runs tests for `inngest-spring-boot-adapter`.
+- `make test-springboot-demo` runs tests for `inngest-spring-boot-demo`.
+- `make lint` runs `ktlint --color`.
+- `make fmt` runs `ktlint -F`.
+
+CI runs tests across multiple Java and Spring Boot versions. When changing
+Spring adapter or demo behavior, consider relevant `SPRING_BOOT_VERSION`
+coverage in addition to the default `2.7.18`.
+
+## Project Architecture
+
+- `inngest/src/main/kotlin/com/inngest/` contains the core SDK API, function
+  configuration, event and step handling, request handling, environment logic,
+  HTTP client behavior, and signing key verification.
+- `inngest/src/main/kotlin/com/inngest/ktor/` contains Ktor route integration.
+- `inngest/src/test/kotlin/` and `inngest/src/test/resources/protocol/` contain
+  shared SDK and protocol contract tests and fixtures.
+- `inngest/src/testFixtures/` exposes reusable Java test fixtures for adapter
+  tests.
+- `inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/` contains
+  the Spring Boot controller and configuration layer.
+- `inngest-spring-boot-demo/` exercises the adapter and hosts integration tests.
+- `inngest-test-server/` provides a lightweight Ktor server for local SDK
+  testing.
+
+## Working Style
+
+- Prefer minimal, targeted changes that preserve existing Kotlin and Java style.
+- Keep public SDK behavior and wire shapes compatible with protocol fixtures and
+  plan notes unless the task explicitly changes the contract.
+- Add or update focused tests for behavior changes. Use shared fixtures when
+  changing cross-adapter request handling.
+- Run the most relevant module tests before handing work back when practical.
+- Run `make lint` or `make fmt` when formatting-sensitive Kotlin or Java files
+  are edited.
+- Commits should be small logical chunks so each one is self reviewable.
+- If operating from a plan in `docs/plans/`, update checklist items as work is
+  completed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ TEST_ARGS=--console=rich --warning-mode=all
 GRADLE=./gradlew
 SPRING_BOOT_VERSION?=2.7.18
 SPRING_BOOT_ARGS=-PspringBootVersion=$(SPRING_BOOT_VERSION)
+TEST_JAVA_VERSION?=
+TEST_JAVA_ARGS=$(if $(TEST_JAVA_VERSION),-PtestJavaVersion=$(TEST_JAVA_VERSION),)
 
 .PHONY: dev-ktor
 dev-ktor:
@@ -16,23 +18,23 @@ test: test-core test-ktor test-springboot-adapter test-springboot-demo
 
 .PHONY: itest
 itest:
-	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) -p inngest-spring-boot-demo integrationTest
+	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) $(TEST_JAVA_ARGS) -p inngest-spring-boot-demo integrationTest
 
 .PHONY: test-core
 test-core:
-	$(GRADLE) test $(TEST_ARGS) -p inngest
+	$(GRADLE) test $(TEST_ARGS) $(TEST_JAVA_ARGS) -p inngest
 
 .PHONY: test-ktor
 test-ktor:
-	$(GRADLE) test $(TEST_ARGS) -p inngest-test-server
+	$(GRADLE) test $(TEST_ARGS) $(TEST_JAVA_ARGS) -p inngest-test-server
 
 .PHONY: test-springboot-demo
 test-springboot-demo:
-	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) -p inngest-spring-boot-demo
+	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) $(TEST_JAVA_ARGS) -p inngest-spring-boot-demo
 
 .PHONY: test-springboot-adapter
 test-springboot-adapter:
-	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) -p inngest-spring-boot-adapter
+	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) $(TEST_JAVA_ARGS) -p inngest-spring-boot-adapter
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 TEST_ARGS=--console=rich --warning-mode=all
 GRADLE=./gradlew
+SPRING_BOOT_VERSION?=2.7.18
+SPRING_BOOT_ARGS=-PspringBootVersion=$(SPRING_BOOT_VERSION)
 
 .PHONY: dev-ktor
 dev-ktor:
@@ -7,14 +9,14 @@ dev-ktor:
 
 .PHONY: dev-spring-boot
 dev-spring-boot:
-	$(GRADLE) inngest-spring-boot-demo:bootRun
+	$(GRADLE) $(SPRING_BOOT_ARGS) inngest-spring-boot-demo:bootRun
 
 .PHONY: test
-test: test-core test-ktor test-springboot-demo
+test: test-core test-ktor test-springboot-adapter test-springboot-demo
 
 .PHONY: itest
 itest:
-	$(GRADLE) test $(TEST_ARGS) -p inngest-spring-boot-demo integrationTest
+	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) -p inngest-spring-boot-demo integrationTest
 
 .PHONY: test-core
 test-core:
@@ -26,7 +28,11 @@ test-ktor:
 
 .PHONY: test-springboot-demo
 test-springboot-demo:
-	$(GRADLE) test $(TEST_ARGS) -p inngest-spring-boot-demo
+	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) -p inngest-spring-boot-demo
+
+.PHONY: test-springboot-adapter
+test-springboot-adapter:
+	$(GRADLE) test $(TEST_ARGS) $(SPRING_BOOT_ARGS) -p inngest-spring-boot-adapter
 
 .PHONY: lint
 lint:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/inngest-spring-boot-adapter/build.gradle.kts
+++ b/inngest-spring-boot-adapter/build.gradle.kts
@@ -16,6 +16,8 @@ plugins {
 }
 
 java {
+    // Spring Boot 3+ moved its runtime baseline to Java 17. Keep Boot 2.x
+    // publishing on Java 8 so the adapter remains usable by legacy apps.
     sourceCompatibility =
         if (springBootMajorVersion.get() >= 3) {
             JavaVersion.VERSION_17
@@ -46,6 +48,8 @@ val testJavaVersion = providers.gradleProperty("testJavaVersion").map { it.toInt
 
 dependencyManagement {
     imports {
+        // Import the Spring Boot BOM directly instead of applying the Boot
+        // Gradle plugin; the Boot 2.7 plugin is not compatible with Gradle 9.
         mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion.get()}") {
             bomProperty("kotlin.version", "1.9.10")
         }
@@ -142,6 +146,8 @@ tasks.javadoc {
 
 tasks.withType<Test> {
     testJavaVersion.orNull?.let { version ->
+        // The CI matrix asks for each Java version explicitly. Boot 3/4 tests
+        // still need at least Java 17, so clamp older requested JVMs upward.
         val minimumVersion = if (springBootMajorVersion.get() >= 3) 17 else 8
         javaLauncher.set(
             javaToolchains.launcherFor {

--- a/inngest-spring-boot-adapter/build.gradle.kts
+++ b/inngest-spring-boot-adapter/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("java-library")
     id("maven-publish")
     id("signing")
-    id("io.spring.dependency-management") version "1.1.4"
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 java {

--- a/inngest-spring-boot-adapter/build.gradle.kts
+++ b/inngest-spring-boot-adapter/build.gradle.kts
@@ -5,6 +5,9 @@ group = "com.inngest"
 description = "Spring Boot adapter for Inngest SDK"
 version = file("VERSION").readText().trim()
 
+val springBootVersion = providers.gradleProperty("springBootVersion").orElse("2.7.18")
+val springBootMajorVersion = springBootVersion.map { it.substringBefore(".").toInt() }
+
 plugins {
     id("java-library")
     id("maven-publish")
@@ -13,7 +16,12 @@ plugins {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility =
+        if (springBootMajorVersion.get() >= 3) {
+            JavaVersion.VERSION_17
+        } else {
+            JavaVersion.VERSION_1_8
+        }
     withJavadocJar()
     withSourcesJar()
 }
@@ -29,12 +37,14 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation(testFixtures(project(":inngest")))
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.fasterxml.jackson.core:jackson-databind")
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.boot:spring-boot-dependencies:2.7.18") {
+        mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion.get()}") {
             bomProperty("kotlin.version", "1.9.10")
         }
     }

--- a/inngest-spring-boot-adapter/build.gradle.kts
+++ b/inngest-spring-boot-adapter/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
+val testJavaVersion = providers.gradleProperty("testJavaVersion").map { it.toInt() }
+
 dependencyManagement {
     imports {
         mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion.get()}") {
@@ -139,6 +141,15 @@ tasks.javadoc {
 }
 
 tasks.withType<Test> {
+    testJavaVersion.orNull?.let { version ->
+        val minimumVersion = if (springBootMajorVersion.get() >= 3) 17 else 8
+        javaLauncher.set(
+            javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(maxOf(version, minimumVersion)))
+            },
+        )
+    }
+
     useJUnitPlatform()
 
     testLogging {

--- a/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
+++ b/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
@@ -12,8 +12,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.NativeWebRequest;
 
-import javax.servlet.http.HttpServletRequest;
+import java.lang.reflect.InvocationTargetException;
 
 public abstract class InngestController {
     @Autowired
@@ -44,9 +45,9 @@ public abstract class InngestController {
     public ResponseEntity<String> put(
         @RequestHeader(HttpHeaders.HOST) String hostHeader,
         @RequestHeader(name = "X-Inngest-Server-Kind", required = false) String serverKind,
-        HttpServletRequest request
+        NativeWebRequest request
     ) {
-        String origin = String.format("%s://%s", request.getScheme(), hostHeader);
+        String origin = String.format("%s://%s", getRequestScheme(request), hostHeader);
         if (this.serveOrigin != null && !this.serveOrigin.isEmpty()) {
             origin = this.serveOrigin;
         }
@@ -60,6 +61,24 @@ public abstract class InngestController {
         response.getHeaders().forEach(headers::add);
 
         return ResponseEntity.status(response.getStatusCode()).headers(headers).body(response.getBody());
+    }
+
+    private String getRequestScheme(NativeWebRequest request) {
+        Object nativeRequest = request.getNativeRequest();
+        if (nativeRequest == null) {
+            return "http";
+        }
+
+        try {
+            Object scheme = nativeRequest.getClass().getMethod("getScheme").invoke(nativeRequest);
+            if (scheme instanceof String && !((String) scheme).isEmpty()) {
+                return (String) scheme;
+            }
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException ignored) {
+            return "http";
+        }
+
+        return "http";
     }
 
     @PostMapping()

--- a/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
+++ b/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
@@ -70,6 +70,8 @@ public abstract class InngestController {
         }
 
         try {
+            // Avoid referencing servlet request types directly here: Spring
+            // Boot 2 exposes javax.servlet, while Boot 3/4 expose jakarta.servlet.
             Object scheme = nativeRequest.getClass().getMethod("getScheme").invoke(nativeRequest);
             if (scheme instanceof String && !((String) scheme).isEmpty()) {
                 return (String) scheme;

--- a/inngest-spring-boot-demo/build.gradle.kts
+++ b/inngest-spring-boot-demo/build.gradle.kts
@@ -7,6 +7,8 @@ val springBootMajorVersion = springBootVersion.map { it.substringBefore(".").toI
 plugins {
     java
     application
+    // Use the dependency-management plugin plus a local bootRun task below.
+    // Applying the Spring Boot Gradle plugin would break Boot 2.7 on Gradle 9.
     id("io.spring.dependency-management") version "1.1.7"
 }
 
@@ -14,6 +16,8 @@ group = "com.inngest"
 version = "0.0.1-SNAPSHOT"
 
 java {
+    // Spring Boot 3+ requires Java 17, while Boot 2.x can still compile for
+    // Java 8. This demo follows the selected Boot version's baseline.
     sourceCompatibility =
         if (springBootMajorVersion.get() >= 3) {
             JavaVersion.VERSION_17
@@ -44,12 +48,15 @@ dependencies {
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     if (springBootMajorVersion.get() >= 4) {
+        // Spring Boot 4 moved MVC test support out of starter-test.
         testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     }
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     val effectiveTestJavaVersion = testJavaVersion.orNull ?: JavaVersion.current().majorVersion.toInt()
+    // system-stubs 2.x requires Java 11. Keep 1.2.1 available for the Boot 2
+    // / Java 8 matrix entries.
     if (effectiveTestJavaVersion >= 11) {
         testImplementation("uk.org.webcompere:system-stubs-jupiter:2.1.6")
     } else {
@@ -59,6 +66,8 @@ dependencies {
 
 dependencyManagement {
     imports {
+        // Import the BOM directly so the selected Spring Boot version controls
+        // dependency alignment without applying version-specific Boot tasks.
         mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion.get()}") {
             bomProperty("kotlin.version", "1.9.10")
         }
@@ -67,6 +76,8 @@ dependencyManagement {
 
 tasks.withType<Test> {
     testJavaVersion.orNull?.let { version ->
+        // CI includes Java 8/11 entries for compatibility, but Boot 3/4 cannot
+        // run below Java 17. Use the requested JVM unless the Boot baseline is higher.
         val minimumVersion = if (springBootMajorVersion.get() >= 3) 17 else 8
         javaLauncher.set(
             javaToolchains.launcherFor {
@@ -129,6 +140,9 @@ tasks.withType<Test> {
 tasks.register<Test>("integrationTest") {
     description = "Runs Spring Boot demo integration tests."
     group = "verification"
+    // Reuse the standard test source set and switch groups with a system
+    // property. Creating a separate source set makes these tests disappear
+    // under the current Gradle 9 setup.
     testClassesDirs = sourceSets["test"].output.classesDirs
     classpath = sourceSets["test"].runtimeClasspath
     shouldRunAfter(tasks.test)
@@ -139,6 +153,8 @@ tasks.register<Test>("integrationTest") {
 tasks.register<JavaExec>("bootRun") {
     group = "application"
     description = "Runs the Spring Boot demo application."
+    // Local replacement for the Spring Boot plugin's bootRun task so the demo
+    // can still be exercised against Boot 2.7 on Gradle 9.
     classpath = sourceSets["main"].runtimeClasspath
     mainClass.set(application.mainClass)
 }

--- a/inngest-spring-boot-demo/build.gradle.kts
+++ b/inngest-spring-boot-demo/build.gradle.kts
@@ -6,9 +6,8 @@ val springBootMajorVersion = springBootVersion.map { it.substringBefore(".").toI
 
 plugins {
     java
-    id("org.springframework.boot")
-    id("io.spring.dependency-management") version "1.1.4"
-    id("io.freefair.lombok") version "8.6"
+    application
+    id("io.spring.dependency-management") version "1.1.7"
 }
 
 group = "com.inngest"
@@ -23,6 +22,10 @@ java {
         }
 }
 
+application {
+    mainClass.set("com.inngest.springbootdemo.SpringBootDemoApplication")
+}
+
 repositories {
     mavenCentral()
 }
@@ -33,6 +36,9 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
+
+    compileOnly("org.projectlombok:lombok:1.18.46")
+    annotationProcessor("org.projectlombok:lombok:1.18.46")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     if (springBootMajorVersion.get() >= 4) {
@@ -109,6 +115,18 @@ tasks.withType<Test> {
 }
 
 tasks.register<Test>("integrationTest") {
+    description = "Runs Spring Boot demo integration tests."
+    group = "verification"
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    shouldRunAfter(tasks.test)
     systemProperty("test-group", "integration-test")
     systemProperty("junit.jupiter.execution.parallel.enabled", false)
+}
+
+tasks.register<JavaExec>("bootRun") {
+    group = "application"
+    description = "Runs the Spring Boot demo application."
+    classpath = sourceSets["main"].runtimeClasspath
+    mainClass.set(application.mainClass)
 }

--- a/inngest-spring-boot-demo/build.gradle.kts
+++ b/inngest-spring-boot-demo/build.gradle.kts
@@ -30,6 +30,8 @@ repositories {
     mavenCentral()
 }
 
+val testJavaVersion = providers.gradleProperty("testJavaVersion").map { it.toInt() }
+
 dependencies {
     implementation(project(":inngest-spring-boot-adapter"))
 
@@ -47,7 +49,8 @@ dependencies {
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
-    if (JavaVersion.current().isJava11Compatible) {
+    val effectiveTestJavaVersion = testJavaVersion.orNull ?: JavaVersion.current().majorVersion.toInt()
+    if (effectiveTestJavaVersion >= 11) {
         testImplementation("uk.org.webcompere:system-stubs-jupiter:2.1.6")
     } else {
         testImplementation("uk.org.webcompere:system-stubs-jupiter:1.2.1")
@@ -63,6 +66,15 @@ dependencyManagement {
 }
 
 tasks.withType<Test> {
+    testJavaVersion.orNull?.let { version ->
+        val minimumVersion = if (springBootMajorVersion.get() >= 3) 17 else 8
+        javaLauncher.set(
+            javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(maxOf(version, minimumVersion)))
+            },
+        )
+    }
+
     useJUnitPlatform()
     systemProperty("junit.jupiter.execution.parallel.enabled", true)
     systemProperty("test-group", "unit-test")

--- a/inngest-spring-boot-demo/build.gradle.kts
+++ b/inngest-spring-boot-demo/build.gradle.kts
@@ -1,9 +1,12 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
+val springBootVersion = providers.gradleProperty("springBootVersion").orElse("2.7.18")
+val springBootMajorVersion = springBootVersion.map { it.substringBefore(".").toInt() }
+
 plugins {
     java
-    id("org.springframework.boot") version "2.7.18"
+    id("org.springframework.boot")
     id("io.spring.dependency-management") version "1.1.4"
     id("io.freefair.lombok") version "8.6"
 }
@@ -12,7 +15,12 @@ group = "com.inngest"
 version = "0.0.1-SNAPSHOT"
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility =
+        if (springBootMajorVersion.get() >= 3) {
+            JavaVersion.VERSION_17
+        } else {
+            JavaVersion.VERSION_1_8
+        }
 }
 
 repositories {
@@ -23,10 +31,15 @@ dependencies {
     implementation(project(":inngest-spring-boot-adapter"))
 
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    if (springBootMajorVersion.get() >= 4) {
+        testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
+    }
     testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     if (JavaVersion.current().isJava11Compatible) {
         testImplementation("uk.org.webcompere:system-stubs-jupiter:2.1.6")
@@ -37,7 +50,7 @@ dependencies {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.boot:spring-boot-dependencies:2.7.18") {
+        mavenBom("org.springframework.boot:spring-boot-dependencies:${springBootVersion.get()}") {
             bomProperty("kotlin.version", "1.9.10")
         }
     }

--- a/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/DevServerComponent.java
+++ b/inngest-spring-boot-demo/src/main/java/com/inngest/springbootdemo/DevServerComponent.java
@@ -6,14 +6,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.inngest.CommHandler;
 import com.inngest.InngestSystem;
 import okhttp3.Request;
-import javax.annotation.PreDestroy;
 import okhttp3.OkHttpClient;
 import okhttp3.Response;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.boot.web.context.WebServerApplicationContext;
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.event.EventListener;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -24,7 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
-public class DevServerComponent {
+public class DevServerComponent implements DisposableBean {
     @FunctionalInterface
     interface CheckedBooleanSupplier {
         boolean getAsBoolean() throws Exception;
@@ -47,8 +47,7 @@ public class DevServerComponent {
             return;
         }
 
-        WebServerApplicationContext applicationContext = (WebServerApplicationContext) event.getApplicationContext();
-        int appPort = applicationContext.getWebServer().getPort();
+        int appPort = getWebServerPort(event);
         String appOrigin = "http://127.0.0.1:" + appPort;
         this.baseUrl = configuredDevServerBaseUrl();
         int devServerPort = URI.create(baseUrl).getPort();
@@ -59,6 +58,22 @@ public class DevServerComponent {
 
         waitForStartup(appOrigin);
         started = true;
+    }
+
+    private int getWebServerPort(ApplicationReadyEvent event) {
+        Object applicationContext = event.getApplicationContext();
+
+        try {
+            Object webServer = applicationContext.getClass().getMethod("getWebServer").invoke(applicationContext);
+            Object port = webServer.getClass().getMethod("getPort").invoke(webServer);
+            if (port instanceof Number) {
+                return ((Number) port).intValue();
+            }
+        } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new IllegalStateException("Application context does not expose an embedded web server port", e);
+        }
+
+        throw new IllegalStateException("Application context returned a non-numeric embedded web server port");
     }
 
     private List<String> devServerCommand(
@@ -303,8 +318,8 @@ public class DevServerComponent {
     }
 
 
-    @PreDestroy
-    public void stop()  {
+    @Override
+    public void destroy() {
         if (devServerProcess != null && devServerProcess.isAlive()) {
             devServerProcess.destroy();
         }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CloudModeIntrospectionTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CloudModeIntrospectionTest.java
@@ -4,16 +4,23 @@ import com.inngest.*;
 import com.inngest.signingkey.BearerTokenKt;
 import com.inngest.signingkey.SignatureVerificationKt;
 import com.inngest.springboot.InngestConfiguration;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -23,6 +30,7 @@ import java.util.HashMap;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+@Configuration
 class ProductionConfiguration extends InngestConfiguration {
 
     public static final String INNGEST_APP_ID = "spring_test_prod_demo";
@@ -66,13 +74,22 @@ public class CloudModeIntrospectionTest {
 
     // The nested class is useful for setting the environment variables before the configuration class (Beans) runs.
     // https://www.baeldung.com/java-system-stubs#environment-and-property-overrides-for-junit-5-spring-tests
+    @WebAppConfiguration
+    @ContextConfiguration(classes = {DemoController.class, ProductionConfiguration.class, TestWebMvcConfiguration.class})
     @Import(ProductionConfiguration.class)
-    @WebMvcTest(DemoController.class)
+    @ExtendWith(SpringExtension.class)
     @Nested
     @EnabledIfSystemProperty(named = "test-group", matches = "unit-test")
     class InnerSpringTest {
         @Autowired
+        private WebApplicationContext webApplicationContext;
+
         private MockMvc mockMvc;
+
+        @BeforeEach
+        void setUpMockMvc() {
+            mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+        }
 
         @Test
         public void shouldReturnInsecureIntrospectionWhenSignatureIsMissing() throws Exception {
@@ -135,5 +152,10 @@ public class CloudModeIntrospectionTest {
                     .andExpect(jsonPath("$.sdk_version").value(Version.Companion.getVersion()))
                     .andExpect(jsonPath("$.signing_key_hash").value(expectedSigningKeyHash));
         }
+    }
+
+    @Configuration
+    @EnableWebMvc
+    static class TestWebMvcConfiguration {
     }
 }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CloudModeIntrospectionTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CloudModeIntrospectionTest.java
@@ -30,33 +30,6 @@ import java.util.HashMap;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Configuration
-class ProductionConfiguration extends InngestConfiguration {
-
-    public static final String INNGEST_APP_ID = "spring_test_prod_demo";
-
-    @Override
-    protected HashMap<String, InngestFunction> functions() {
-        return new HashMap<>();
-    }
-
-    @Override
-    protected Inngest inngestClient() {
-        return new Inngest(INNGEST_APP_ID);
-    }
-
-    @Override
-    protected ServeConfig serve(Inngest client) {
-        return new ServeConfig(client);
-    }
-
-    @Bean
-    protected CommHandler commHandler(@Autowired Inngest inngestClient) {
-        ServeConfig serveConfig = new ServeConfig(inngestClient);
-        return new CommHandler(functions(), inngestClient, serveConfig, SupportedFrameworkName.SpringBoot);
-    }
-}
-
 @ExtendWith(SystemStubsExtension.class)
 public class CloudModeIntrospectionTest {
 
@@ -70,6 +43,33 @@ public class CloudModeIntrospectionTest {
         environmentVariables.set("INNGEST_DEV", "0");
         environmentVariables.set("INNGEST_SIGNING_KEY", productionSigningKey);
         environmentVariables.set("INNGEST_EVENT_KEY", productionEventKey);
+    }
+
+    @Configuration
+    static class ProductionConfiguration extends InngestConfiguration {
+
+        public static final String INNGEST_APP_ID = "spring_test_prod_demo";
+
+        @Override
+        protected HashMap<String, InngestFunction> functions() {
+            return new HashMap<>();
+        }
+
+        @Override
+        protected Inngest inngestClient() {
+            return new Inngest(INNGEST_APP_ID);
+        }
+
+        @Override
+        protected ServeConfig serve(Inngest client) {
+            return new ServeConfig(client);
+        }
+
+        @Bean
+        protected CommHandler commHandler(@Autowired Inngest inngestClient) {
+            ServeConfig serveConfig = new ServeConfig(inngestClient);
+            return new CommHandler(functions(), inngestClient, serveConfig, SupportedFrameworkName.SpringBoot);
+        }
     }
 
     // The nested class is useful for setting the environment variables before the configuration class (Beans) runs.

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CloudModeIntrospectionTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/CloudModeIntrospectionTest.java
@@ -72,7 +72,9 @@ public class CloudModeIntrospectionTest {
         }
     }
 
-    // The nested class is useful for setting the environment variables before the configuration class (Beans) runs.
+    // Keep the production config nested so full-app demo tests do not component-scan it and
+    // collide with DemoTestConfiguration's CommHandler bean. The nested test also lets
+    // system-stubs set environment variables before Spring creates the beans.
     // https://www.baeldung.com/java-system-stubs#environment-and-property-overrides-for-junit-5-spring-tests
     @WebAppConfiguration
     @ContextConfiguration(classes = {DemoController.class, ProductionConfiguration.class, TestWebMvcConfiguration.class})

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DevModeIntrospectionTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/DevModeIntrospectionTest.java
@@ -7,9 +7,9 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -18,10 +18,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Execution(ExecutionMode.CONCURRENT)
 public class DevModeIntrospectionTest {
     @Autowired
-    private MockMvc mockMvc;
+    private WebApplicationContext webApplicationContext;
 
     @Test
     public void shouldReturnInsecureIntrospectPayload() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+
         mockMvc.perform(get("/api/inngest").header("Host", "localhost:8080"))
             .andExpect(status().isOk())
             .andExpect(content().contentType("application/json"))

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/IntegrationTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/IntegrationTest.java
@@ -1,7 +1,6 @@
 package com.inngest.springbootdemo;
 
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ContextConfiguration;
@@ -14,6 +13,5 @@ import java.lang.annotation.RetentionPolicy;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @Import(DemoTestConfiguration.class)
 @ContextConfiguration(initializers = IntegrationTestInitializer.class)
-@AutoConfigureMockMvc
 public @interface IntegrationTest {
 }

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/SpringBootDemoApplicationTests.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/SpringBootDemoApplicationTests.java
@@ -5,11 +5,8 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.annotation.IfProfileValue;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -18,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @IntegrationTest
 @Import(DemoTestConfiguration.class)
-@AutoConfigureMockMvc
 @Execution(ExecutionMode.CONCURRENT)
 class SpringBootDemoApplicationIntegrationTest {
     @Value("${TEST_URL:http://localhost:8080}")

--- a/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/SyncRequestTest.java
+++ b/inngest-spring-boot-demo/src/test/java/com/inngest/springbootdemo/SyncRequestTest.java
@@ -11,10 +11,16 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -28,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(SystemStubsExtension.class)
 public class SyncRequestTest {
+    @Configuration
     static class SyncInngestConfiguration extends InngestConfiguration {
         protected HashMap<String, InngestFunction> functions() {
             return new HashMap<>();
@@ -55,17 +62,22 @@ public class SyncRequestTest {
 
     public static MockWebServer mockWebServer;
 
+    @WebAppConfiguration
+    @ContextConfiguration(classes = {DemoController.class, SyncInngestConfiguration.class, TestWebMvcConfiguration.class})
     @Import(SyncInngestConfiguration.class)
-    @WebMvcTest(DemoController.class)
+    @ExtendWith(SpringExtension.class)
     @Nested
     @EnabledIfSystemProperty(named = "test-group", matches = "unit-test")
     @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
     class InnerSpringTest {
         @Autowired
+        private WebApplicationContext webApplicationContext;
+
         private MockMvc mockMvc;
 
         @BeforeEach
         void BeforeEach() throws Exception {
+            mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
             mockWebServer = new MockWebServer();
             mockWebServer.start();
 
@@ -132,5 +144,10 @@ public class SyncRequestTest {
             assertEquals("3", recordedRequest.getRequestUrl().queryParameter("deployId"));
             assertThatPayloadDoesNotContainDeployId(recordedRequest);
         }
+    }
+
+    @Configuration
+    @EnableWebMvc
+    static class TestWebMvcConfiguration {
     }
 }

--- a/inngest-test-server/build.gradle.kts
+++ b/inngest-test-server/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-annotations:2.16.1")
 }
 
+val testJavaVersion = providers.gradleProperty("testJavaVersion").map { it.toInt() }
+
 // Apply a specific Java toolchain to ease working on different environments.
 java { toolchain { languageVersion.set(JavaLanguageVersion.of(17)) } }
 
@@ -41,6 +43,14 @@ application {
 }
 
 tasks.named<Test>("test") {
+    testJavaVersion.orNull?.let { version ->
+        javaLauncher.set(
+            javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(maxOf(version, 17)))
+            },
+        )
+    }
+
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 

--- a/inngest-test-server/build.gradle.kts
+++ b/inngest-test-server/build.gradle.kts
@@ -5,7 +5,7 @@ description = "Inngest Test Server"
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    id("org.jetbrains.kotlin.jvm") version "1.9.10"
+    id("org.jetbrains.kotlin.jvm") version "2.2.21"
 
     // Apply the application plugin to add support for building a CLI application in Java.
     application

--- a/inngest/build.gradle.kts
+++ b/inngest/build.gradle.kts
@@ -25,6 +25,8 @@ repositories {
     mavenCentral()
 }
 
+val testJavaVersion = providers.gradleProperty("testJavaVersion").map { it.toInt() }
+
 dependencies {
     implementation("com.beust:klaxon:5.5")
     implementation("com.fasterxml.jackson.core:jackson-core:2.16.1")
@@ -131,6 +133,21 @@ tasks.javadoc {
 }
 
 tasks.named<Test>("test") {
+    val effectiveTestJavaVersion = testJavaVersion.orNull?.let { maxOf(it, 8) } ?: 8
+    testJavaVersion.orNull?.let { version ->
+        javaLauncher.set(
+            javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(maxOf(version, 8)))
+            },
+        )
+    }
+    if (effectiveTestJavaVersion >= 17) {
+        jvmArgs(
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+        )
+    }
+
     // Use JUnit Platform for unit tests.
     useJUnitPlatform()
 

--- a/inngest/build.gradle.kts
+++ b/inngest/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
     id("java-test-fixtures")
     id("maven-publish")
     id("signing")
-    id("org.jetbrains.kotlin.jvm") version "1.9.10"
+    id("org.jetbrains.kotlin.jvm") version "2.2.21"
 }
 
 // TODO - Move this to share conventions gradle file

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "inngest-sdk"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,19 @@
  * For more detailed information on multi-project builds, please refer to https://docs.gradle.org/8.4/userguide/building_swift_projects.html in the Gradle documentation.
  */
 
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+
+    val springBootVersion = providers.gradleProperty("springBootVersion").orElse("2.7.18").get()
+
+    plugins {
+        id("org.springframework.boot") version springBootVersion
+    }
+}
+
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"


### PR DESCRIPTION
## Summary

Adds Spring Boot compatibility coverage across 2.7.18, 3.5.14, and 4.0.6, and expands Java coverage through Java 25 where the selected Spring Boot line supports it. This also updates the Spring Boot adapter and demo for the Boot 3/4 Jakarta stack and the Gradle 9 / Java 25 runtime path.

Changes:

- Test the Spring Boot adapter and demo against a Spring Boot and Java compatibility matrix.
- Cover Spring Boot 2.7.18 on Java 8, 11, 17, and 21; Java 25 coverage is limited to Spring Boot 3/4.
- Run Gradle itself on Java 21 while using Gradle toolchains for the requested test JVM.
- Run Spring Boot demo integration tests on Depot 4 CPU runners.
- Keep Spring Boot 2.x compatible with Java 8 while clamping Boot 3/4 tests to Java 17 or newer.
- Add comments around version-sensitive Spring Boot and Gradle compatibility choices.
- Isolate cloud-mode Spring test configuration so it does not collide with full demo integration tests.

## Checklist

- [x] Update documentation
- [x] Added unit/integration tests
