### PR TITLE
feat(inngest): expand execution request model

### DIFF
--- a/docs/plans/002-expand-execution-request-model.org
+++ b/docs/plans/002-expand-execution-request-model.org
@@ -14,11 +14,9 @@
 - [ ] Backward-compatible parsing for current tests and fixtures where feasible.
 
 * Status Notes
-- Checked against the current repository state on 2026-05-15: no plan 002
-  checklist items are implemented yet.
-- =ExecutionContext= currently parses only =attempt=, =fn_id=, =run_id=, and
-  =env=. It does not parse =disable_immediate_execution=, =use_api=,
-  =stack=, or =qi_id=.
+- Implementation started on 2026-05-19. Shared core parsing now carries the
+  richer execution request context while keeping =FunctionContext= focused on
+  developer-facing fields.
 - Ktor and Spring adapters currently validate =fnId= and pass only the function
   ID plus request body into =CommHandler=. They do not capture or thread the
   inbound =stepId= query parameter.
@@ -35,12 +33,12 @@
   implementation.
 
 * Checklist
-- [ ] Extend =ExecutionContext= to include =disable_immediate_execution=, =use_api=, and stack metadata.
+- [X] Extend =ExecutionContext= to include =disable_immediate_execution=, =use_api=, and stack metadata.
 - [ ] Add =stepId= handling in Ktor and Spring request boundaries and thread it into shared execution.
-- [ ] Add =qi_id= support in the internal model even if checkpointing is deferred.
-- [ ] Introduce a dedicated internal execution context type if =FunctionContext= should stay user-facing and minimal.
-- [ ] Thread the richer execution context through =CommHandler= and the internal function engine.
-- [ ] Preserve backward-compatible parsing defaults for old/minimal fixtures while new context fields are optional in tests.
+- [X] Add =qi_id= support in the internal model even if checkpointing is deferred.
+- [X] Introduce a dedicated internal execution context type if =FunctionContext= should stay user-facing and minimal.
+- [X] Thread the richer execution context through =CommHandler= and the internal function engine.
+- [X] Preserve backward-compatible parsing defaults for old/minimal fixtures while new context fields are optional in tests.
 - [ ] Update fixtures and builders from milestone 000 to emit the richer request body.
 - [ ] Add tests for parsing and preserving the new request fields.
 - [ ] Audit direct JSON parsing assumptions in shared code and adapters.

--- a/docs/plans/002-expand-execution-request-model.org
+++ b/docs/plans/002-expand-execution-request-model.org
@@ -1,17 +1,17 @@
 #+title: 002 Expand Execution Request Model
 #+AUTHOR: Darwin D. Wu
 #+DATE: 2026-04-16
-#+STATUS: Draft
+#+STATUS: Done
 
 * Goal
-- [ ] Extend the execution request model to carry the full context required by the spec.
-- [ ] Stop encoding execution assumptions in scattered parsing logic.
+- [X] Extend the execution request model to carry the full context required by the spec.
+- [X] Stop encoding execution assumptions in scattered parsing logic.
 
 * Scope
-- [ ] Shared execution payload types.
-- [ ] Internal execution context threading.
-- [ ] Adapter request-boundary query parameters needed by shared execution.
-- [ ] Backward-compatible parsing for current tests and fixtures where feasible.
+- [X] Shared execution payload types.
+- [X] Internal execution context threading.
+- [X] Adapter request-boundary query parameters needed by shared execution.
+- [X] Backward-compatible parsing for current tests and fixtures where feasible.
 
 * Status Notes
 - Implementation started on 2026-05-19. Shared core parsing now carries the
@@ -22,14 +22,17 @@
 - Function registration already emits runtime URLs with =fnId= and
   =stepId=step=, but this plan covers the receiving side of those query
   parameters, not registration URL generation.
-- Current protocol fixtures still emit the older minimal execution context.
-  Add nullable/default parsing for new context fields first, then expand
-  fixtures and assertions once shared code can carry the richer model.
+- Protocol fixtures now emit the richer execution context by default, while
+  tests still cover older minimal payloads for backward-compatible parsing.
 - The upstream SDK spec currently requires =ctx.disable_immediate_execution=,
   =ctx.use_api=, and =ctx.stack= for Call Requests, and provides =ctx.qi_id=
   for async checkpointing. Checkpoint behavior can remain deferred, but parsing
   and threading the queue item ID should not be blocked by checkpoint
   implementation.
+- Direct JSON parsing audit: execution payload parsing remains centralized in
+  =CommHandler=; Ktor and Spring adapters pass through request bodies plus query
+  parameters; =State= still reads =steps= from the request body until payload
+  recovery and planned-step execution are implemented in later plans.
 
 * Checklist
 - [X] Extend =ExecutionContext= to include =disable_immediate_execution=, =use_api=, and stack metadata.
@@ -38,10 +41,10 @@
 - [X] Introduce a dedicated internal execution context type if =FunctionContext= should stay user-facing and minimal.
 - [X] Thread the richer execution context through =CommHandler= and the internal function engine.
 - [X] Preserve backward-compatible parsing defaults for old/minimal fixtures while new context fields are optional in tests.
-- [ ] Update fixtures and builders from milestone 000 to emit the richer request body.
-- [ ] Add tests for parsing and preserving the new request fields.
-- [ ] Audit direct JSON parsing assumptions in shared code and adapters.
+- [X] Update fixtures and builders from milestone 000 to emit the richer request body.
+- [X] Add tests for parsing and preserving the new request fields.
+- [X] Audit direct JSON parsing assumptions in shared code and adapters.
 
 * Exit Criteria
-- [ ] Shared code can parse and carry all context required for payload recovery and planned-step execution.
-- [ ] Request parsing no longer blocks later milestones such as step planning or checkpointing.
+- [X] Shared code can parse and carry all context required for payload recovery and planned-step execution.
+- [X] Request parsing no longer blocks later milestones such as step planning or checkpointing.

--- a/docs/plans/002-expand-execution-request-model.org
+++ b/docs/plans/002-expand-execution-request-model.org
@@ -10,14 +10,37 @@
 * Scope
 - [ ] Shared execution payload types.
 - [ ] Internal execution context threading.
+- [ ] Adapter request-boundary query parameters needed by shared execution.
 - [ ] Backward-compatible parsing for current tests and fixtures where feasible.
+
+* Status Notes
+- Checked against the current repository state on 2026-05-15: no plan 002
+  checklist items are implemented yet.
+- =ExecutionContext= currently parses only =attempt=, =fn_id=, =run_id=, and
+  =env=. It does not parse =disable_immediate_execution=, =use_api=,
+  =stack=, or =qi_id=.
+- Ktor and Spring adapters currently validate =fnId= and pass only the function
+  ID plus request body into =CommHandler=. They do not capture or thread the
+  inbound =stepId= query parameter.
+- Function registration already emits runtime URLs with =fnId= and
+  =stepId=step=, but this plan covers the receiving side of those query
+  parameters, not registration URL generation.
+- Current protocol fixtures still emit the older minimal execution context.
+  Add nullable/default parsing for new context fields first, then expand
+  fixtures and assertions once shared code can carry the richer model.
+- The upstream SDK spec currently requires =ctx.disable_immediate_execution=,
+  =ctx.use_api=, and =ctx.stack= for Call Requests, and provides =ctx.qi_id=
+  for async checkpointing. Checkpoint behavior can remain deferred, but parsing
+  and threading the queue item ID should not be blocked by checkpoint
+  implementation.
 
 * Checklist
 - [ ] Extend =ExecutionContext= to include =disable_immediate_execution=, =use_api=, and stack metadata.
-- [ ] Add =stepId= handling at the request boundary and thread it into execution.
+- [ ] Add =stepId= handling in Ktor and Spring request boundaries and thread it into shared execution.
 - [ ] Add =qi_id= support in the internal model even if checkpointing is deferred.
 - [ ] Introduce a dedicated internal execution context type if =FunctionContext= should stay user-facing and minimal.
 - [ ] Thread the richer execution context through =CommHandler= and the internal function engine.
+- [ ] Preserve backward-compatible parsing defaults for old/minimal fixtures while new context fields are optional in tests.
 - [ ] Update fixtures and builders from milestone 000 to emit the richer request body.
 - [ ] Add tests for parsing and preserving the new request fields.
 - [ ] Audit direct JSON parsing assumptions in shared code and adapters.

--- a/docs/plans/002-expand-execution-request-model.org
+++ b/docs/plans/002-expand-execution-request-model.org
@@ -17,9 +17,8 @@
 - Implementation started on 2026-05-19. Shared core parsing now carries the
   richer execution request context while keeping =FunctionContext= focused on
   developer-facing fields.
-- Ktor and Spring adapters currently validate =fnId= and pass only the function
-  ID plus request body into =CommHandler=. They do not capture or thread the
-  inbound =stepId= query parameter.
+- Ktor and Spring adapters now capture the inbound =stepId= query parameter and
+  pass it into =CommHandler=.
 - Function registration already emits runtime URLs with =fnId= and
   =stepId=step=, but this plan covers the receiving side of those query
   parameters, not registration URL generation.
@@ -34,7 +33,7 @@
 
 * Checklist
 - [X] Extend =ExecutionContext= to include =disable_immediate_execution=, =use_api=, and stack metadata.
-- [ ] Add =stepId= handling in Ktor and Spring request boundaries and thread it into shared execution.
+- [X] Add =stepId= handling in Ktor and Spring request boundaries and thread it into shared execution.
 - [X] Add =qi_id= support in the internal model even if checkpointing is deferred.
 - [X] Introduce a dedicated internal execution context type if =FunctionContext= should stay user-facing and minimal.
 - [X] Thread the richer execution context through =CommHandler= and the internal function engine.

--- a/docs/plans/003-implement-payload-recovery-from-api.org
+++ b/docs/plans/003-implement-payload-recovery-from-api.org
@@ -10,12 +10,30 @@
 - [ ] HTTP client support for GET requests and authenticated API calls.
 - [ ] Batch event retrieval.
 - [ ] Memoized step retrieval.
+- [ ] Integration with the richer execution request model from plan 002.
+
+* Status Notes
+- Checked against the current repository state on 2026-05-15: no plan 003
+  checklist items are implemented yet.
+- Plan 002 is a prerequisite for this work. =ExecutionContext= currently does
+  not parse =ctx.use_api=, =ctx.disable_immediate_execution=, or
+  =ctx.stack=, so payload recovery cannot be triggered from request context yet.
+- =HttpClient= currently only builds JSON =POST= requests. Recovery needs a
+  shared =GET= path that preserves SDK headers and outbound authentication.
+- =State= currently reads memoized step data from the raw request body. Recovery
+  should make the fully recovered =steps= object available before function
+  execution and step memoization begin.
+- The upstream SDK spec currently requires both recovery calls to use the API
+  origin, global outbound headers, and bearer-token authorization based on the
+  hashed signing key. Signing-key fallback is tracked in plan 006, but plan 003
+  should avoid creating an API-auth path that would make fallback harder to add.
 
 * Checklist
 - [ ] Extend the internal HTTP client to support GET requests with shared headers and auth.
+- [ ] Parse and thread =ctx.use_api= from the execution request model once plan 002 lands.
 - [ ] Implement =GET /v0/runs/:run_id/batch= retrieval.
 - [ ] Implement =GET /v0/runs/:run_id/actions= retrieval.
-- [ ] Add request signing/auth header support to these API calls using the same base config path as sync.
+- [ ] Add request signing/auth header support to these API calls using the same base config path as sync and a shape compatible with signing-key fallback.
 - [ ] Replace the request payload =events= and =event= when the batch API succeeds.
 - [ ] Replace memoized step data when the actions API succeeds.
 - [ ] Return a protocol failure when either required fetch fails or returns non-200.

--- a/inngest-ktor-adapter/src/main/kotlin/com/inngest/ktor/Route.kt
+++ b/inngest-ktor-adapter/src/main/kotlin/com/inngest/ktor/Route.kt
@@ -55,6 +55,7 @@ fun Route.serve(
 
         post("") {
             val fnId = call.request.queryParameters["fnId"]
+            val stepId = call.request.queryParameters["stepId"]
             if (fnId == null) {
                 val response = comm.protocolErrorResponse(IllegalArgumentException("Missing fnId parameter"))
                 call.respondComm(response)
@@ -65,7 +66,7 @@ fun Route.serve(
                     val serverKind = call.request.headers[InngestHeaderKey.ServerKind.value]
                     checkHeadersAndValidateSignature(signature, body, serverKind, comm.config)
 
-                    val response = comm.callFunction(fnId, body)
+                    val response = comm.callFunction(fnId, body, stepId)
                     call.respondComm(response)
                 } catch (e: Exception) {
                     val response = comm.protocolErrorResponse(e)

--- a/inngest-ktor-adapter/src/test/kotlin/com/inngest/ktor/RouteTest.kt
+++ b/inngest-ktor-adapter/src/test/kotlin/com/inngest/ktor/RouteTest.kt
@@ -45,7 +45,7 @@ internal class RouteTest {
             }
 
             val response =
-                client.post("/api/inngest?fnId=echo-fn") {
+                client.post("/api/inngest?fnId=echo-fn&stepId=step") {
                     contentType(ContentType.Application.Json)
                     setBody(ProtocolFixtures.executionRequestPayloadJson("echo-fn"))
                 }
@@ -71,7 +71,7 @@ internal class RouteTest {
             }
 
             val response =
-                client.post("/api/inngest?fnId=echo-fn") {
+                client.post("/api/inngest?fnId=echo-fn&stepId=step") {
                     header(InngestHeaderKey.ServerKind.value, "cloud")
                     contentType(ContentType.Application.Json)
                     setBody(ProtocolFixtures.executionRequestPayloadJson("echo-fn"))

--- a/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
+++ b/inngest-spring-boot-adapter/src/main/java/com/inngest/springboot/InngestController.java
@@ -88,6 +88,7 @@ public abstract class InngestController {
         @RequestHeader(name = "X-Inngest-Signature", required = false) String signature,
         @RequestHeader(name = "X-Inngest-Server-Kind", required = false) String serverKind,
         @RequestParam(name = "fnId", required = false) String functionId,
+        @RequestParam(name = "stepId", required = false) String stepId,
         @RequestBody String body
     ) {
         try {
@@ -97,7 +98,7 @@ public abstract class InngestController {
 
             SignatureVerificationKt.checkHeadersAndValidateSignature(signature, body, serverKind, commHandler.getConfig());
 
-            CommResponse response = commHandler.callFunction(functionId, body);
+            CommResponse response = commHandler.callFunction(functionId, body, stepId);
 
             return commResponse(response);
         } catch (Exception e) {

--- a/inngest-spring-boot-adapter/src/test/java/com/inngest/springboot/InngestControllerTest.java
+++ b/inngest-spring-boot-adapter/src/test/java/com/inngest/springboot/InngestControllerTest.java
@@ -72,8 +72,9 @@ public class InngestControllerTest {
 
     @Test
     void postRouteReturnsCallResponseWithRequiredHeaders() throws Exception {
-        String responseBody = mockMvc.perform(post("/api/inngest")
+            String responseBody = mockMvc.perform(post("/api/inngest")
                 .queryParam("fnId", "echo-fn")
+                .queryParam("stepId", "step")
                 .contentType("application/json")
                 .content(ProtocolFixtures.executionRequestPayloadJson("echo-fn")))
             .andExpect(status().isOk())
@@ -92,6 +93,7 @@ public class InngestControllerTest {
 
         String responseBody = mockMvc.perform(post("/api/inngest")
                 .queryParam("fnId", "echo-fn")
+                .queryParam("stepId", "step")
                 .header(InngestHeaderKey.ServerKind.getValue(), "cloud")
                 .contentType("application/json")
                 .content(ProtocolFixtures.executionRequestPayloadJson("echo-fn")))

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -16,12 +16,67 @@ data class ExecutionRequestPayload(
     val steps: MemoizedState,
 )
 
+data class ExecutionStack
+    @JvmOverloads
+    constructor(
+        val stack: List<String> = emptyList(),
+        val current: Int = 0,
+    )
+
 data class ExecutionContext(
     val attempt: Int,
     @Json(name = "fn_id") val fnId: String,
     @Json(name = "run_id") val runId: String,
     val env: String,
+    @Json(name = "disable_immediate_execution") val disableImmediateExecution: Boolean = false,
+    @Json(name = "use_api") val useApi: Boolean = false,
+    val stack: ExecutionStack = ExecutionStack(),
+    @Json(name = "qi_id") val queueItemId: String? = null,
 )
+
+internal const val DEFAULT_STEP_ID = "step"
+
+internal data class ExecutionRequestContext(
+    val functionId: String,
+    val runId: String,
+    val attempt: Int,
+    val env: String,
+    val stepId: String,
+    val disableImmediateExecution: Boolean,
+    val useApi: Boolean,
+    val stack: ExecutionStack,
+    val queueItemId: String?,
+) {
+    fun toFunctionContext(
+        event: Event,
+        events: List<Event>,
+    ): FunctionContext =
+        FunctionContext(
+            event = event,
+            events = events,
+            runId = runId,
+            fnId = functionId,
+            attempt = attempt,
+        )
+
+    companion object {
+        fun from(
+            ctx: ExecutionContext,
+            stepId: String?,
+        ): ExecutionRequestContext =
+            ExecutionRequestContext(
+                functionId = ctx.fnId,
+                runId = ctx.runId,
+                attempt = ctx.attempt,
+                env = ctx.env,
+                stepId = stepId?.takeIf { it.isNotBlank() } ?: DEFAULT_STEP_ID,
+                disableImmediateExecution = ctx.disableImmediateExecution,
+                useApi = ctx.useApi,
+                stack = ctx.stack,
+                queueItemId = ctx.queueItemId,
+            )
+    }
+}
 
 internal data class RegistrationRequestPayload
     @JvmOverloads
@@ -101,25 +156,21 @@ class CommHandler(
     private val allFunctions = baseFunctions.plus(failureFunctions)
     private val functionsById = indexFunctions(allFunctions, client.appId)
 
+    @JvmOverloads
     fun callFunction(
         functionId: String,
         requestBody: String,
+        stepId: String? = DEFAULT_STEP_ID,
     ): CommResponse {
         try {
             val payload = Klaxon().parse<ExecutionRequestPayload>(requestBody)
             // TODO - check that payload is not null and throw error
             val function = functionsById[functionId] ?: throw Exception("Function not found")
+            val execution = ExecutionRequestContext.from(payload!!.ctx, stepId)
 
-            val ctx =
-                FunctionContext(
-                    event = payload!!.event,
-                    events = payload.events,
-                    runId = payload.ctx.runId,
-                    fnId = payload.ctx.fnId,
-                    attempt = payload.ctx.attempt,
-                )
+            val ctx = execution.toFunctionContext(payload.event, payload.events)
 
-            val result = function.call(ctx = ctx, client = client, requestBody)
+            val result = function.call(ctx = ctx, execution = execution, client = client, requestBody)
             var body: Any? = null
             if (result.statusCode in stepTerminalStatusCodes || result is StepOptions) {
                 body = listOf(result)

--- a/inngest/src/main/kotlin/com/inngest/Comm.kt
+++ b/inngest/src/main/kotlin/com/inngest/Comm.kt
@@ -23,16 +23,18 @@ data class ExecutionStack
         val current: Int = 0,
     )
 
-data class ExecutionContext(
-    val attempt: Int,
-    @Json(name = "fn_id") val fnId: String,
-    @Json(name = "run_id") val runId: String,
-    val env: String,
-    @Json(name = "disable_immediate_execution") val disableImmediateExecution: Boolean = false,
-    @Json(name = "use_api") val useApi: Boolean = false,
-    val stack: ExecutionStack = ExecutionStack(),
-    @Json(name = "qi_id") val queueItemId: String? = null,
-)
+data class ExecutionContext
+    @JvmOverloads
+    constructor(
+        val attempt: Int,
+        @Json(name = "fn_id") val fnId: String,
+        @Json(name = "run_id") val runId: String,
+        val env: String,
+        @Json(name = "disable_immediate_execution") val disableImmediateExecution: Boolean = false,
+        @Json(name = "use_api") val useApi: Boolean = false,
+        val stack: ExecutionStack = ExecutionStack(),
+        @Json(name = "qi_id") val queueItemId: String? = null,
+    )
 
 internal const val DEFAULT_STEP_ID = "step"
 

--- a/inngest/src/main/kotlin/com/inngest/Function.kt
+++ b/inngest/src/main/kotlin/com/inngest/Function.kt
@@ -158,6 +158,8 @@ internal open class InternalInngestFunction(
 
     fun call(
         ctx: FunctionContext,
+        @Suppress("UNUSED_PARAMETER")
+        execution: ExecutionRequestContext,
         client: Inngest,
         requestBody: String,
     ): StepOp {

--- a/inngest/src/test/java/com/inngest/ExecutionContextJavaInteropTest.java
+++ b/inngest/src/test/java/com/inngest/ExecutionContextJavaInteropTest.java
@@ -1,0 +1,23 @@
+package com.inngest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ExecutionContextJavaInteropTest {
+    @Test
+    void preservesFourArgumentConstructor() {
+        ExecutionContext ctx = new ExecutionContext(2, "fn-id", "run-id", "test");
+
+        assertEquals(2, ctx.getAttempt());
+        assertEquals("fn-id", ctx.getFnId());
+        assertEquals("run-id", ctx.getRunId());
+        assertEquals("test", ctx.getEnv());
+        assertFalse(ctx.getDisableImmediateExecution());
+        assertFalse(ctx.getUseApi());
+        assertEquals(new ExecutionStack(), ctx.getStack());
+        assertNull(ctx.getQueueItemId());
+    }
+}

--- a/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
@@ -1,5 +1,6 @@
 package com.inngest
 
+import com.beust.klaxon.Klaxon
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.inngest.testing.ProtocolFixtures
@@ -7,6 +8,8 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
@@ -79,6 +82,97 @@ internal class CommHandlerTest {
 
         assertEquals(ResultStatusCode.FunctionComplete, response.statusCode)
         assertEquals("done", mapper.readValue(response.body, String::class.java))
+    }
+
+    @Test
+    fun `execution request parses and preserves spec context fields`() {
+        val payload =
+            Klaxon().parse<ExecutionRequestPayload>(
+                """
+                {
+                  "ctx": {
+                    "attempt": 2,
+                    "fn_id": "echo-fn",
+                    "run_id": "run-test",
+                    "env": "branch",
+                    "disable_immediate_execution": true,
+                    "use_api": true,
+                    "stack": {
+                      "stack": ["first", "second"],
+                      "current": 1
+                    },
+                    "qi_id": "qi-test"
+                  },
+                  "event": {
+                    "name": "test/run",
+                    "data": {
+                      "message": "hello"
+                    }
+                  },
+                  "events": [
+                    {
+                      "name": "test/run",
+                      "data": {
+                        "message": "hello"
+                      }
+                    }
+                  ],
+                  "steps": {}
+                }
+                """.trimIndent(),
+            )!!
+        val execution = ExecutionRequestContext.from(payload.ctx, "target-step")
+
+        assertEquals("echo-fn", execution.functionId)
+        assertEquals("run-test", execution.runId)
+        assertEquals(2, execution.attempt)
+        assertEquals("branch", execution.env)
+        assertEquals("target-step", execution.stepId)
+        assertTrue(execution.disableImmediateExecution)
+        assertTrue(execution.useApi)
+        assertEquals(listOf("first", "second"), execution.stack.stack)
+        assertEquals(1, execution.stack.current)
+        assertEquals("qi-test", execution.queueItemId)
+    }
+
+    @Test
+    fun `execution request defaults new context fields for minimal payloads`() {
+        val payload =
+            Klaxon().parse<ExecutionRequestPayload>(
+                """
+                {
+                  "ctx": {
+                    "attempt": 0,
+                    "fn_id": "echo-fn",
+                    "run_id": "run-test",
+                    "env": "test"
+                  },
+                  "event": {
+                    "name": "test/run",
+                    "data": {
+                      "message": "hello"
+                    }
+                  },
+                  "events": [
+                    {
+                      "name": "test/run",
+                      "data": {
+                        "message": "hello"
+                      }
+                    }
+                  ],
+                  "steps": {}
+                }
+                """.trimIndent(),
+            )!!
+        val execution = ExecutionRequestContext.from(payload.ctx, null)
+
+        assertFalse(execution.disableImmediateExecution)
+        assertFalse(execution.useApi)
+        assertEquals(emptyList<String>(), execution.stack.stack)
+        assertEquals(0, execution.stack.current)
+        assertNull(execution.queueItemId)
+        assertEquals(DEFAULT_STEP_ID, execution.stepId)
     }
 
     @Test

--- a/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
+++ b/inngest/src/test/kotlin/com/inngest/CommHandlerTest.kt
@@ -176,6 +176,18 @@ internal class CommHandlerTest {
     }
 
     @Test
+    fun `protocol fixture emits richer execution context`() {
+        val payload = mapper.readTree(ProtocolFixtures.executionRequestPayloadJson("echo-fn"))
+        val ctx = payload["ctx"]
+
+        assertFalse(ctx["disable_immediate_execution"].asBoolean())
+        assertFalse(ctx["use_api"].asBoolean())
+        assertEquals(0, ctx["stack"]["current"].asInt())
+        assertTrue(ctx["stack"]["stack"].isArray)
+        assertEquals("qi-test", ctx["qi_id"].asText())
+    }
+
+    @Test
     fun `callFunction marks non-retriable errors correctly`() {
         val response =
             commHandler(NonRetriableFailureFunction())

--- a/inngest/src/testFixtures/java/com/inngest/testing/ProtocolFixtures.java
+++ b/inngest/src/testFixtures/java/com/inngest/testing/ProtocolFixtures.java
@@ -91,6 +91,15 @@ public final class ProtocolFixtures {
         ctx.put("fn_id", functionId);
         ctx.put("run_id", "run-test");
         ctx.put("env", "test");
+        ctx.put("disable_immediate_execution", false);
+        ctx.put("use_api", false);
+
+        LinkedHashMap<String, Object> stack = new LinkedHashMap<>();
+        stack.put("stack", Collections.emptyList());
+        stack.put("current", 0);
+        ctx.put("stack", stack);
+        ctx.put("qi_id", "qi-test");
+
         return ctx;
     }
 }


### PR DESCRIPTION
## Summary

Implements plan 002 by expanding the execution request model so shared code can carry the spec-required call context for payload recovery and planned-step execution.

Changes:

* Parse and thread `disable_immediate_execution`, `use_api`, `stack`, and `qi_id` through an internal execution context.
* Capture inbound `stepId` in Ktor and Spring adapters and pass it into shared execution.
* Expand protocol fixtures and tests for richer execution request payloads while preserving minimal-payload compatibility.
* Preserve the Java four-argument `ExecutionContext` constructor with an interop test.
* Mark plan 002 complete.

## Checklist

- [x] Update documentation
- [x] Added unit/integration tests

## Related

- Plan: `docs/plans/002-expand-execution-request-model.org`